### PR TITLE
[FIX] 카카오 소셜 로그인 -> 프론트엔드로 토큰 리다이렉트 코드 추가

### DIFF
--- a/src/main/java/com/deardream/deardream_be/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/deardream/deardream_be/domain/auth/controller/AuthController.java
@@ -12,6 +12,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 import io.jsonwebtoken.Jwts;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
 
 @RestController
 @RequestMapping("/api/users")
@@ -27,7 +30,7 @@ public class AuthController {
 
 
     @GetMapping("/login/kakao")         // 여기로 들어오는 code가 카카오가 준 인가코드
-    public ApiResponse<KakaoLoginResponseDTO> kakaoLogin(@RequestParam("code") String code, HttpServletResponse response) {
+    public void kakaoLogin(@RequestParam("code") String code, HttpServletResponse response) {
 
         // 1. 카카오 로그인 처리 (accessCode → User)
         User user = authService.loginWithKakao(code);
@@ -40,14 +43,31 @@ public class AuthController {
         redisUtil.setDataExpire("refresh:" + user.getEmail(), refreshToken, REFRESH_EXP_TIME);
 
         // 3. 응답 DTO 구성
-        KakaoLoginResponseDTO loginResponse = KakaoLoginResponseDTO.builder()
-                .email(user.getEmail())
-                .name(user.getName())
-                .accessToken(accessToken)
-                .refreshToken(refreshToken)
-                .build();
+//        KakaoLoginResponseDTO loginResponse = KakaoLoginResponseDTO.builder()
+//                .email(user.getEmail())
+//                .name(user.getName())
+//                .accessToken(accessToken)
+//                .refreshToken(refreshToken)
+//                .build();
+//
+//        return ApiResponse.onSuccess(loginResponse);
 
-        return ApiResponse.onSuccess(loginResponse);
+        // 4. 프론트엔드로 리다이렉트 (쿼리 파라미터로 토큰 전달)
+        String frontendCallback = "http://localhost:3000/auth/login";
+        String redirectUrl = UriComponentsBuilder
+                .fromUriString(frontendCallback)
+                .queryParam("accessToken",  accessToken)
+                .queryParam("refreshToken", refreshToken)
+                .build()
+                .toUriString();
+
+        try{
+            response.sendRedirect(redirectUrl);
+            log.info("[KakaoLogin] Redirect to → {}", redirectUrl);
+
+        } catch (IOException e) {
+            log.error("리다이렉트 실패", e);
+        }
     }
 
 


### PR DESCRIPTION
카카오 소셜 로그인 -> 프론트엔드로 토큰 리다이렉트 코드 추가했습니다