### PR TITLE
fix: ArchiveListResponse 직렬화 오류 해결 #10

### DIFF
--- a/src/main/java/com/deardream/deardream_be/domain/archive/dto/ArchiveListResponse.java
+++ b/src/main/java/com/deardream/deardream_be/domain/archive/dto/ArchiveListResponse.java
@@ -1,10 +1,13 @@
 package com.deardream.deardream_be.domain.archive.dto;
 
-import lombok.Builder;
+import lombok.*;
 
 import java.util.List;
 
 @Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class ArchiveListResponse {
     private int count;
     private List<ArchiveResponseDto> dtos;


### PR DESCRIPTION
## 해결 사항
- Get 요청으로 pdfUrl 을 볼 때 전체 pdf 개수를 반환해 주어야 합니다.
- 이를 추가 시 Dto 내에 List<Dto> 가 존재하여 역직렬화 문제가 발생해 오류 수정하였습니다. #10 

## 추가해야 하는 사항
- 후에 썸네일 사진 추가 가 필요 합니다.