### PR TITLE
[FIX] 연관관계 매핑 수정(기관 테이블의 pk 수정으로 인한 잘못된 연관관계 해결)

### DIFF
--- a/src/main/java/com/deardream/deardream_be/domain/recipient/entity/Recipient.java
+++ b/src/main/java/com/deardream/deardream_be/domain/recipient/entity/Recipient.java
@@ -64,7 +64,7 @@ public class Recipient extends BaseEntity {
     private String postalCode;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "code")
+    @JoinColumn(name = "code", referencedColumnName = "code")
     private Institution institution;
 
 


### PR DESCRIPTION
### - pr 요약
---
연관관계 매핑 수정(기관 테이블의 pk 수정으로 인해 code->code 참조가 아닌 code->id 참조하고 있었음)
그래서 code->code 참조하게 수정했습니다