### PR TITLE
[FEAT] 대표자는 수신자를 한 번만 등록할 수 있게 예외처리 로직 추가

### DIFF
--- a/src/main/java/com/deardream/deardream_be/domain/recipient/repository/RecipientRepository.java
+++ b/src/main/java/com/deardream/deardream_be/domain/recipient/repository/RecipientRepository.java
@@ -11,5 +11,5 @@ public interface RecipientRepository extends JpaRepository<Recipient, Long> {
     Optional<Recipient> findByFamilyId(Long familyId);
     List<Recipient> findAllByInstitution(Institution institution);
     Optional<Recipient> findByLeaderId(Long leaderId);
-
+    boolean existsByLeaderId(Long leaderId);
 }

--- a/src/main/java/com/deardream/deardream_be/domain/recipient/service/RecipientServiceImplementation.java
+++ b/src/main/java/com/deardream/deardream_be/domain/recipient/service/RecipientServiceImplementation.java
@@ -54,6 +54,12 @@ public class RecipientServiceImplementation implements RecipientService {
         User user = userRepository.findByKakaoId(kakaoId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
 
+        // 1-1. 이미 등록된 수신자가 있는지 사전 검사
+        boolean recipientExists = recipientRepository.existsByLeaderId(user.getId());
+        if (recipientExists) {
+            throw new GeneralException(ErrorStatus._RECIPIENT_ALREADY_REGISTERED);
+        }
+
         user.joinRecipientMakerAsLeader();
         userRepository.save(user);
 

--- a/src/main/java/com/deardream/deardream_be/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/deardream/deardream_be/global/apiPayload/code/status/ErrorStatus.java
@@ -62,6 +62,7 @@ public enum ErrorStatus implements BaseErrorCode {
     _IMAGE_SIZE_EXCEEDED(HttpStatus.FORBIDDEN, "403", "이미지 크기가 너무 큽니다. 최대 5MB까지 가능합니다."),
     _NOT_AUTHOR_OF_POST(HttpStatus.FORBIDDEN, "403", "해당 게시글의 작성자가 아닙니다."),
     _NOT_FAMILY_MEMBER(HttpStatus.FORBIDDEN, "403", "해당 가족의 구성원이 아닙니다."),
+    _RECIPIENT_ALREADY_REGISTERED(HttpStatus.FORBIDDEN, "403", "이미 수신자가 등록되어 있습니다. 수신자 수정을 이용해 주세요."),
 
     // 404 Not Found
     _TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "404", "해당 토큰을 찾을 수 없습니다."),


### PR DESCRIPTION
### - pr 요약
---
수신자테이블에 저장되는 같은 기관코드는 여러 개일 수 있지만
대표자 1명에 수신자는 1명 등록되는게 맞음

현재 대표자가 수신자를 1번 등록했음에도 다시 등록되는 오류가 있어서
대표자가 수신자를 반복 등록하려 할 시 RECIPIENT_ALREADY_REGISTERED 에러가 뜨는 예외처리 로직 추가