### PR TITLE
[FEAT] [FIX] 가족 초대장, 가족 초대 링크 생성 관련 로직 수정

### DIFF
--- a/src/main/java/com/deardream/deardream_be/domain/family/controller/FamilyController.java
+++ b/src/main/java/com/deardream/deardream_be/domain/family/controller/FamilyController.java
@@ -1,5 +1,6 @@
 package com.deardream.deardream_be.domain.family.controller;
 
+import com.deardream.deardream_be.domain.family.dto.FamilyInvitationDto;
 import com.deardream.deardream_be.domain.family.dto.FamilyMembersResponseDto;
 import com.deardream.deardream_be.domain.family.dto.FamilyResponseDto;
 import com.deardream.deardream_be.domain.family.service.FamilyService;
@@ -40,9 +41,19 @@ public class FamilyController {
         return ApiResponse.onSuccess(familyMembersResponseDto);
     }
 
-    // 3) 초대 링크 생성 (LEADER)
-    @GetMapping("/link")
-    public ApiResponse<String> getInviteLink(
+    // 3) 가족 초대장 정보 조회 (토큰 없음) - 추가
+    @GetMapping("/invitation")
+    public ApiResponse<FamilyInvitationDto> getMyInvitation(
+            @RequestParam("code") String inviteCode
+    ) {
+        FamilyInvitationDto familyInvitation = familyService.getMyFamilyInvitation(inviteCode);
+        return ApiResponse.onSuccess(familyInvitation);
+    }
+
+
+    // 4) 초대 링크 생성 (LEADER)
+    @PostMapping("/link")
+    public ApiResponse<String> createInviteLink(
             Authentication authentication
     ) {
         CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
@@ -52,7 +63,18 @@ public class FamilyController {
         return ApiResponse.onSuccess(link);
     }
 
-    // 4) 초대 링크로 가입 (role=USER)
+
+    // 5) 초대 링크 조회 - 추가
+    @GetMapping("/link")
+    public ApiResponse<String> getInviteLink(Authentication authentication) {
+        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+        Long kakaoId = userDetails.getKakaoId();
+        String link = familyService.getInviteLink(kakaoId);
+
+        return ApiResponse.onSuccess(link);
+    }
+
+    // 5) 초대 링크로 가입 (role=USER)
     @PostMapping("/join")
     public ApiResponse<Void> joinByInvite(
             @RequestParam("code") String inviteCode,

--- a/src/main/java/com/deardream/deardream_be/domain/family/dto/FamilyInvitationDto.java
+++ b/src/main/java/com/deardream/deardream_be/domain/family/dto/FamilyInvitationDto.java
@@ -1,0 +1,11 @@
+package com.deardream.deardream_be.domain.family.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class FamilyInvitationDto {
+    private String leaderName;
+    private String recipientName;
+}

--- a/src/main/java/com/deardream/deardream_be/domain/family/dto/FamilyMembersResponseDto.java
+++ b/src/main/java/com/deardream/deardream_be/domain/family/dto/FamilyMembersResponseDto.java
@@ -19,12 +19,13 @@ public class FamilyMembersResponseDto {
     private LocalDateTime createdAt;
     private String leaderName;
     private String recipientName;
+    private String recipientProfileImage;
     private List<UserResponseDto> members;
 
 
     // family엔티티 + 해당 familyId에 속한 User 리스트를
     // UserResponseDto로 매핑한 뒤 dto에 담아 반환함
-    public static FamilyMembersResponseDto of(Family family, List<User> users, String leaderName, String recipientName) {
+    public static FamilyMembersResponseDto of(Family family, List<User> users, String leaderName, String recipientName, String recipientProfileImage) {
         List<UserResponseDto> memberDtos = users.stream()
                 .map(UserResponseDto::of)
                 .collect(Collectors.toList());
@@ -36,6 +37,7 @@ public class FamilyMembersResponseDto {
                 .members(memberDtos)
                 .leaderName(leaderName)
                 .recipientName(recipientName)
+                .recipientProfileImage(recipientProfileImage)
                 .build();
     }
 }

--- a/src/main/java/com/deardream/deardream_be/domain/family/service/FamilyService.java
+++ b/src/main/java/com/deardream/deardream_be/domain/family/service/FamilyService.java
@@ -1,5 +1,6 @@
 package com.deardream.deardream_be.domain.family.service;
 
+import com.deardream.deardream_be.domain.family.dto.FamilyInvitationDto;
 import com.deardream.deardream_be.domain.family.dto.FamilyMembersResponseDto;
 import com.deardream.deardream_be.domain.family.dto.FamilyResponseDto;
 
@@ -11,10 +12,16 @@ public interface FamilyService {
     // 내 가족 정보 조회
     FamilyMembersResponseDto getMyFamily(Long kakaoId);
 
+    // 내 가족 초대장 조회
+    FamilyInvitationDto getMyFamilyInvitation(String inviteCode);
+
     // 초대 링크 생성
     String createInviteLink(Long kakaoId);
 
+    // 초대 링크 조회
+    String getInviteLink(Long kakaoId);
+
     // 초대 링크를 통해 가족 가입 (user 권한 부여)
-    void joinByInvite(String link, Long kakaoId);
+    void joinByInvite(String inviteCode, Long kakaoId);
 
 }

--- a/src/main/java/com/deardream/deardream_be/domain/family/service/FamilyServiceImplementation.java
+++ b/src/main/java/com/deardream/deardream_be/domain/family/service/FamilyServiceImplementation.java
@@ -1,5 +1,6 @@
 package com.deardream.deardream_be.domain.family.service;
 
+import com.deardream.deardream_be.domain.family.dto.FamilyInvitationDto;
 import com.deardream.deardream_be.domain.family.dto.FamilyMembersResponseDto;
 import com.deardream.deardream_be.domain.family.dto.FamilyRequestDto;
 import com.deardream.deardream_be.domain.family.dto.FamilyResponseDto;
@@ -101,9 +102,43 @@ public class FamilyServiceImplementation implements FamilyService {
                     .orElse(null);
         }
 
+        // 3-3. 수신자 이미지 반환
+        String recipientProfileImage = null;
+        if (leader != null) {
+            recipientProfileImage = recipientRepository.findByLeaderId(leader.getId())
+                    .map(Recipient::getProfileImage)
+                    .orElse(null);
+        }
+
         // 4. dto에 담아 반환
-        return FamilyMembersResponseDto.of(family, familyMembers, leaderName,recipientName);
+        return FamilyMembersResponseDto.of(family, familyMembers, leaderName, recipientName, recipientProfileImage);
     }
+
+
+    @Override
+    @Transactional
+    // 로그인 전 초대장 받았을 때 가족 초대장 조회 api
+    public FamilyInvitationDto getMyFamilyInvitation(String inviteCode) {
+        Family family = familyRepository.findByFamilyLink(inviteCode)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._INVALID_INVITE_LINK));
+
+        User leader = family.getLeader();
+        String leaderName = leader != null ? leader.getName() : null;
+
+        String recipientName = null;
+        if (leader != null) {
+            recipientName = recipientRepository.findByLeaderId(leader.getId())
+                    .map(Recipient::getName)
+                    .orElse(null);
+        }
+
+        return FamilyInvitationDto.builder()
+                .leaderName(leaderName)
+                .recipientName(recipientName)
+                .build();
+    }
+
+
 
     @Override
     @Transactional
@@ -117,21 +152,48 @@ public class FamilyServiceImplementation implements FamilyService {
 
         String inviteLinkToken = family.getFamilyLink();
 
-        // 2. leaderId의 familyLink가 널값인지, 아니면 이미 만들어져 있는지 확인
-        if(inviteLinkToken == null) {
+//        // 2. leaderId의 familyLink가 널값인지, 아니면 이미 만들어져 있는지 확인
+//        if(inviteLinkToken == null) {
+//
+//            // 3. 초대 토큰 생성
+//            inviteLinkToken = UUID.randomUUID().toString();
+//
+//            // 4. 엔티티에 토큰 반영
+//            family.updateFamilyInviteLink(inviteLinkToken);
+//            familyRepository.save(family);
+//        }
+//
+//        // 5. 이미 있다면 초대 url 반환
+//        return inviteLinkToken;
+//        // return String.format("%s/family/join?code=%s", frontendBaseUrl, inviteLinkToken);
 
-            // 3. 초대 토큰 생성
-            inviteLinkToken = UUID.randomUUID().toString();
-
-            // 4. 엔티티에 토큰 반영
-            family.updateFamilyInviteLink(inviteLinkToken);
-            familyRepository.save(family);
+        // 2. 이미 familyLink가 있다면 예외 발생
+        if(inviteLinkToken != null) {
+            throw new GeneralException(ErrorStatus._INVITE_LINK_ALREADY_EXISTS);
         }
 
-        // 5. 이미 있다면 초대 url 반환
-//        return String.format("%s/family/join?code=%s", frontendBaseUrl, inviteLinkToken);
-            return inviteLinkToken;
+        // 3. familyLink가 없을 때만 새로 생성
+        inviteLinkToken = UUID.randomUUID().toString();
+        family.updateFamilyInviteLink(inviteLinkToken);
+        familyRepository.save(family);
+
+        return inviteLinkToken;
     }
+
+    @Override
+    @Transactional
+    public String getInviteLink(Long kakaoId) {
+        User user = userRepository.findByKakaoId(kakaoId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
+
+        Family family = user.getFamily();
+        if (family == null) {
+            throw new GeneralException(ErrorStatus._FAMILY_NOT_FOUND);
+        }
+
+        return family.getFamilyLink();
+    }
+
 
     @Override
     @Transactional

--- a/src/main/java/com/deardream/deardream_be/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/deardream/deardream_be/global/apiPayload/code/status/ErrorStatus.java
@@ -63,6 +63,7 @@ public enum ErrorStatus implements BaseErrorCode {
     _NOT_AUTHOR_OF_POST(HttpStatus.FORBIDDEN, "403", "해당 게시글의 작성자가 아닙니다."),
     _NOT_FAMILY_MEMBER(HttpStatus.FORBIDDEN, "403", "해당 가족의 구성원이 아닙니다."),
     _RECIPIENT_ALREADY_REGISTERED(HttpStatus.FORBIDDEN, "403", "이미 수신자가 등록되어 있습니다. 수신자 수정을 이용해 주세요."),
+    _INVITE_LINK_ALREADY_EXISTS(HttpStatus.FORBIDDEN, "403", "가족 초대 링크가 이미 생성되어 있습니다. 가족 초대 링크 조회를 이용해주세요."),
 
     // 404 Not Found
     _TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "404", "해당 토큰을 찾을 수 없습니다."),

--- a/src/main/java/com/deardream/deardream_be/global/config/SecurityConfig.java
+++ b/src/main/java/com/deardream/deardream_be/global/config/SecurityConfig.java
@@ -50,7 +50,8 @@ public class SecurityConfig {
                                         "/api/v1/archives/**",
                                         "/api/v1/posts/**",
                                 "/api/v1/institutions/**",
-                                        "/api/v1/admin/**"
+                                        "/api/v1/admin/**",
+                                    "api/v1/family/invitation/**"
                                         ).permitAll()
                         .anyRequest().authenticated()
                 )


### PR DESCRIPTION
### - pr 요약
---
[FEAT] GET family/invitation api : 가족 초대장 조회 api 추가
[FIX] 가족 초대 링크 생성 및 조회 api를 링크 생성 / 링크 조회 api 2개로 분할 (링크 생성은 대표자만 가능, 링크 조회는 아무나 가능)
[FIX] GET family api : 가족 전체 조회 할 때 recipient 프로필 사진 반환값에 추가