### PR TITLE
[FEAT] 카카오 로그아웃 기능 추가

### DIFF
--- a/src/main/java/com/deardream/deardream_be/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/deardream/deardream_be/domain/auth/controller/AuthController.java
@@ -10,6 +10,7 @@ import com.deardream.deardream_be.global.apiPayload.exception.GeneralException;
 import com.deardream.deardream_be.global.apiPayload.exception.OnKakaoLoginValidation;
 import com.deardream.deardream_be.global.util.RedisUtil;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Lazy;
@@ -85,26 +86,26 @@ public class AuthController {
 
     @PostMapping("/logout")
     public ApiResponse<String> logout(@RequestHeader("Authorization") String token) {
-
         String accessToken = token.replace("Bearer ", "");
-
-        authService.logout(token);
-
+        authService.logout(accessToken);
         return ApiResponse.onSuccess("로그아웃에 성공했습니다.");
-//
-//        // 1. 토큰에서 kakaoId 추출
-//        Long kakaoId = Long.valueOf(Jwts.parserBuilder()
-//                .setSigningKey(jwtUtil.getSecret().getBytes())
-//                .build()
-//                .parseClaimsJws(accessToken)
-//                .getBody()
-//                .getSubject());
-//
-//        // 2. Redis에서 refresh token 삭제
-//        redisUtil.deleteData("refresh:" + kakaoId);
-//
-//        return ApiResponse.onSuccess("로그아웃 성공");
     }
+
+    @GetMapping("logout/kakao-account")
+    public ApiResponse<String> logoutKakaoAccount(@RequestParam("redirectUri") String logoutRedirectUri) {
+        String url = authService.logoutWithKakaoAccount(logoutRedirectUri);
+        return ApiResponse.onSuccess(url);
+    }
+
+    @GetMapping("/logout/callback")
+    public ApiResponse<String> kakaoAccountLogoutCallback(@RequestHeader(value = "Authorization", required = false) String token) {
+        if (token != null && !token.isBlank()) {
+            String accessToken = token.replace("Bearer ", "");
+            authService.logout(accessToken);
+        }
+        return ApiResponse.onSuccess("카카오 계정 및 서비스 로그아웃 완료");
+    }
+
 
 
 }

--- a/src/main/java/com/deardream/deardream_be/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/deardream/deardream_be/domain/auth/controller/AuthController.java
@@ -91,21 +91,24 @@ public class AuthController {
         return ApiResponse.onSuccess("로그아웃에 성공했습니다.");
     }
 
-    @GetMapping("logout/kakao-account")
-    public ApiResponse<String> logoutKakaoAccount(@RequestParam("redirectUri") String logoutRedirectUri) {
-        String url = authService.logoutWithKakaoAccount(logoutRedirectUri);
-        return ApiResponse.onSuccess(url);
-    }
-
-    @GetMapping("/logout/callback")
-    public ApiResponse<String> kakaoAccountLogoutCallback(@RequestHeader(value = "Authorization", required = false) String token) {
+    @GetMapping("/logout/kakao-account")
+    public ApiResponse<String> logoutKakaoAccount(@RequestHeader(value = "Authorization") String token) {
         if (token != null && !token.isBlank()) {
             String accessToken = token.replace("Bearer ", "");
             authService.logout(accessToken);
         }
-        return ApiResponse.onSuccess("카카오 계정 및 서비스 로그아웃 완료");
+        String logoutRedirectUri = authService.logoutWithKakaoAccount();
+        return ApiResponse.onSuccess(logoutRedirectUri);
     }
 
+//    @GetMapping("/logout/callback")
+//    public ApiResponse<String> kakaoAccountLogoutCallback(@RequestHeader(value = "Authorization", required = false) String token) {
+//        if (token != null && !token.isBlank()) {
+//            String accessToken = token.replace("Bearer ", "");
+//            authService.logout(accessToken);
+//        }
+//        return ApiResponse.onSuccess("카카오 계정 및 서비스 로그아웃 완료");
+//    }
 
 
 }

--- a/src/main/java/com/deardream/deardream_be/domain/auth/service/AuthService.java
+++ b/src/main/java/com/deardream/deardream_be/domain/auth/service/AuthService.java
@@ -6,5 +6,5 @@ import com.deardream.deardream_be.domain.user.entity.User;
 public interface AuthService {
     KakaoLoginResponseDto loginWithKakao(String code, Long familyId); // OAuth 로그인 후 사용자 정보 등록 or 조회
     void logout(String accessToken);
-    String logoutWithKakaoAccount(String logoutRedirectUri);
+    String logoutWithKakaoAccount();
 }

--- a/src/main/java/com/deardream/deardream_be/domain/auth/service/AuthService.java
+++ b/src/main/java/com/deardream/deardream_be/domain/auth/service/AuthService.java
@@ -6,4 +6,5 @@ import com.deardream.deardream_be.domain.user.entity.User;
 public interface AuthService {
     KakaoLoginResponseDto loginWithKakao(String code, Long familyId); // OAuth 로그인 후 사용자 정보 등록 or 조회
     void logout(String accessToken);
+    String logoutWithKakaoAccount(String logoutRedirectUri);
 }

--- a/src/main/java/com/deardream/deardream_be/domain/auth/service/AuthServiceImplementation.java
+++ b/src/main/java/com/deardream/deardream_be/domain/auth/service/AuthServiceImplementation.java
@@ -95,19 +95,19 @@ public class AuthServiceImplementation implements AuthService {
     // 기본 로그아웃 - 토큰만 만료
     public void logout(String accessToken) {
 
-        kakaoUtil.logout(accessToken);
+        // kakaoUtil.logout(accessToken);
 
-        // 2. 토큰에서 kakaoId 추출
+        // 1. jwt 유효성 검사 및 파싱
         Long kakaoId = jwtUtil.getKakaoId(accessToken);
 
-        // 3. refresh 토큰/인증정보 redis에서 삭제
+        // 2. refresh 토큰/인증정보 redis에서 삭제
         redisUtil.deleteData("refresh:" + kakaoId);
 
     }
 
     // 카카오 계정과 함께 로그아웃 -> 카카오 로그아웃 이후 리다이렉트 uri
     // 클라이언트가 이 url로 리다이렉트하면 카카오 계정 세션까지 종료됨
-    public String logoutWithKakaoAccount(String logoutRedirectUri){
-        return kakaoUtil.logoutWithKakaoAccount(logoutRedirectUri);
+    public String logoutWithKakaoAccount(){
+        return kakaoUtil.logoutWithKakaoAccount();
     }
 }

--- a/src/main/java/com/deardream/deardream_be/domain/auth/service/AuthServiceImplementation.java
+++ b/src/main/java/com/deardream/deardream_be/domain/auth/service/AuthServiceImplementation.java
@@ -20,6 +20,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import java.util.Map;
 
@@ -90,22 +92,22 @@ public class AuthServiceImplementation implements AuthService {
     }
 
 
+    // 기본 로그아웃 - 토큰만 만료
     public void logout(String accessToken) {
-//        // 1. 카카오 서버 로그아웃
-//        HttpHeaders headers = new HttpHeaders();
-//        headers.setBearerAuth(accessToken);
-//        HttpEntity<Void> request = new HttpEntity<>(headers);
-//
-//        ResponseEntity<Map> kakaoResponse = restTemplate.exchange(
-//                "https://kapi.kakao.com/v1/user/logout",
-//                HttpMethod.POST,
-//                request,
-//                Map.class
-//        );
-//        Number idNumber = (Number) kakaoResponse.getBody().get("id");
-//        Long kakaoId = idNumber.longValue();
-//
-//        // 2. 내부 리프레시 토큰 삭제
-//        redisUtil.deleteData("refresh:" + kakaoId);
+
+        kakaoUtil.logout(accessToken);
+
+        // 2. 토큰에서 kakaoId 추출
+        Long kakaoId = jwtUtil.getKakaoId(accessToken);
+
+        // 3. refresh 토큰/인증정보 redis에서 삭제
+        redisUtil.deleteData("refresh:" + kakaoId);
+
+    }
+
+    // 카카오 계정과 함께 로그아웃 -> 카카오 로그아웃 이후 리다이렉트 uri
+    // 클라이언트가 이 url로 리다이렉트하면 카카오 계정 세션까지 종료됨
+    public String logoutWithKakaoAccount(String logoutRedirectUri){
+        return kakaoUtil.logoutWithKakaoAccount(logoutRedirectUri);
     }
 }

--- a/src/main/java/com/deardream/deardream_be/domain/auth/util/KakaoUtil.java
+++ b/src/main/java/com/deardream/deardream_be/domain/auth/util/KakaoUtil.java
@@ -4,11 +4,15 @@ import com.deardream.deardream_be.domain.auth.dto.KakaoDto;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.http.*;
+import org.springframework.scheduling.config.ScheduledTaskHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriComponents;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -16,11 +20,22 @@ import org.springframework.web.util.UriComponentsBuilder;
 @Slf4j
 public class KakaoUtil {
 
+    private final ScheduledTaskHolder scheduledTaskHolder;
+    private final RestTemplate restTemplate = new RestTemplate();
+
+
     @Value("${kakao.client-id}")
     private String client;
 
     @Value("${kakao.redirect-uri}")
-    private String redirect;
+    private String redirectUri;
+
+    @Value("${kakao.logout-redirect-uri}")
+    private String logoutRedirectUri;
+
+    public KakaoUtil(ScheduledTaskHolder scheduledTaskHolder) {
+        this.scheduledTaskHolder = scheduledTaskHolder;
+    }
 
     public KakaoDto.OAuthToken getAccessToken(String accessCode) {
         RestTemplate restTemplate = new RestTemplate();
@@ -30,7 +45,7 @@ public class KakaoUtil {
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
         params.add("grant_type", "authorization_code");
         params.add("client_id", client);
-        params.add("redirect_uri", redirect);
+        params.add("redirect_uri", redirectUri);
         params.add("code", accessCode);
 
         // === 여기서 실제로 전달되는 파라미터 값 로그로 남기기 ===
@@ -108,4 +123,51 @@ public class KakaoUtil {
 
         return kakaoProfile;
     }
+
+    // 일반 로그아웃
+    public void logout(String accessToken) {
+
+//        RestTemplate restTemplate = new RestTemplate();
+
+        if(accessToken.startsWith("Bearer ")) {
+            accessToken = accessToken.substring(7);
+        }
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+
+        HttpEntity<Void> request = new HttpEntity<>(headers);
+
+        try{
+            ResponseEntity<String> response = restTemplate.exchange(
+                    "https://kapi.kakao.com/v1/user/logout",
+                    HttpMethod.POST,
+                    request,
+                    String.class
+            );
+            log.info("카카오 토큰 로그아웃 응답 : status={}, body={}", response.getStatusCode(), response.getBody());
+        } catch (HttpClientErrorException.Unauthorized e) {
+            log.error("인증 실패(401) : 토큰이 유효하지 않거나 만료됨", e);
+        }
+        catch (HttpClientErrorException e){
+            log.error("카카오 API 오류 : 상태 코드 {}, 응답 {}", e.getStatusCode(), e.getResponseBodyAsString());
+            throw new RuntimeException("카카오 로그아웃 실패 : " + e.getResponseBodyAsString(), e);
+        }
+        catch (Exception e){
+            log.error("카카오 로그아웃 중 예외 발생", e);
+            throw new RuntimeException("카카오 로그아웃 실패", e);
+        }
+    }
+
+
+    // 카카오계정과 함께 로그아웃 : 계정 세션까지 만료(리다이렉트 url 반환)
+    public String logoutWithKakaoAccount(String logoutRedirectUri) {
+
+        // 카카오 rest api 키로 링크 생성
+        return UriComponentsBuilder
+                .fromHttpUrl("https://kauth.kakao.com/oauth/logout")
+                .queryParam("client_id", client)
+                .queryParam("logout_redirect_uri", logoutRedirectUri)
+                .build().toUriString();
+    }
+
 }

--- a/src/main/java/com/deardream/deardream_be/domain/auth/util/KakaoUtil.java
+++ b/src/main/java/com/deardream/deardream_be/domain/auth/util/KakaoUtil.java
@@ -12,7 +12,6 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
-import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriComponents;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -20,8 +19,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 @Slf4j
 public class KakaoUtil {
 
-    private final ScheduledTaskHolder scheduledTaskHolder;
-    private final RestTemplate restTemplate = new RestTemplate();
+    private final RestTemplate restTemplate;
 
 
     @Value("${kakao.client-id}")
@@ -33,12 +31,11 @@ public class KakaoUtil {
     @Value("${kakao.logout-redirect-uri}")
     private String logoutRedirectUri;
 
-    public KakaoUtil(ScheduledTaskHolder scheduledTaskHolder) {
-        this.scheduledTaskHolder = scheduledTaskHolder;
+    public KakaoUtil(RestTemplate restTemplate) {
+        this.restTemplate = restTemplate;
     }
 
     public KakaoDto.OAuthToken getAccessToken(String accessCode) {
-        RestTemplate restTemplate = new RestTemplate();
         HttpHeaders headers = new HttpHeaders();
         headers.add("Content-Type", "application/x-www-form-urlencoded;charset=utf-8");
 
@@ -84,7 +81,6 @@ public class KakaoUtil {
     }
 
     public KakaoDto.KakaoProfile getUserInfo(String accessToken) {
-        RestTemplate restTemplate = new RestTemplate();
         HttpHeaders headers = new HttpHeaders();
         headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
         headers.add("Authorization", "Bearer " + accessToken);
@@ -127,8 +123,6 @@ public class KakaoUtil {
     // 일반 로그아웃
     public void logout(String accessToken) {
 
-//        RestTemplate restTemplate = new RestTemplate();
-
         if(accessToken.startsWith("Bearer ")) {
             accessToken = accessToken.substring(7);
         }
@@ -160,7 +154,7 @@ public class KakaoUtil {
 
 
     // 카카오계정과 함께 로그아웃 : 계정 세션까지 만료(리다이렉트 url 반환)
-    public String logoutWithKakaoAccount(String logoutRedirectUri) {
+    public String logoutWithKakaoAccount() {
 
         // 카카오 rest api 키로 링크 생성
         return UriComponentsBuilder

--- a/src/main/java/com/deardream/deardream_be/global/config/RestTemplateConfig.java
+++ b/src/main/java/com/deardream/deardream_be/global/config/RestTemplateConfig.java
@@ -1,4 +1,13 @@
 package com.deardream.deardream_be.global.config;
 
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
 public class RestTemplateConfig {
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
 }

--- a/src/main/java/com/deardream/deardream_be/global/config/RestTemplateConfig.java
+++ b/src/main/java/com/deardream/deardream_be/global/config/RestTemplateConfig.java
@@ -1,0 +1,4 @@
+package com.deardream.deardream_be.global.config;
+
+public class RestTemplateConfig {
+}

--- a/src/main/java/com/deardream/deardream_be/global/config/SecurityConfig.java
+++ b/src/main/java/com/deardream/deardream_be/global/config/SecurityConfig.java
@@ -51,7 +51,10 @@ public class SecurityConfig {
                                         "/api/v1/posts/**",
                                 "/api/v1/institutions/**",
                                         "/api/v1/admin/**",
-                                    "api/v1/family/invitation/**"
+                                    "api/v1/family/invitation/**",
+                                        "/api/v1/admin/**",
+                                        "/api/users/logout",
+                                        "/api/users/logout/callback"
                                         ).permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -49,6 +49,7 @@ kakao:
   client-id: ${KAKAO_CLIENT_ID}
   client-secret: ${KAKAO_CLIENT_SECRET}
   redirect-uri: ${KAKAO_REDIRECT_URI}
+  logout-redirect-uri: ${KAKAO_LOGOUT_REDIRECT_URI}
 
 cloud:
   aws:


### PR DESCRIPTION
---
name : 오지현
about : 카카오 로그아웃
title : 카카오 로그아웃 기능 추가 
labels: FEAT
assignees: 한혜수

---

## 📌 작업 내용
- 카카오 로그아웃 로직 추가하고 restTemplateConfig만들어서 주입받아서 사용하도록 리팩토링 했습니다

## 🔍 주요 변경 사항
- Auth폴더 관련 파일들(authController, authService, kakaoUtil 파일이 변경되었습니다.
- 로그아웃 시 두 가지로 동작할 수 있도록 하였습니다.

**1) 일반 로그아웃 : 우리 서비스만 로그아웃(jwt 토큰 만료)**
**2) 카카오 계정과 함께 로그아웃 : 우리 서비스 + 카카오 계정 로그아웃 (jwt 토큰 만료 + 카카오 세션 만료)**

자세한 내용은 아래 사진을 참고하시면 됩니다
<img width="683" height="1361" alt="image" src="https://github.com/user-attachments/assets/415333b4-b4f7-4b65-9945-9e23548ffbd9" />

## 🧪 테스트 결과
- [O] 직접 실행하여 정상 동작 확인함
- [O] 주요 시나리오에 대한 테스트 완료
- [O] 예외 상황/경계 조건 확인함

## 📎 관련 이슈
- 카카오 로그아웃 이슈가 없는데 .. 하나 만들겠습니다

## ✅ 체크리스트
- [O] 빌드/테스트 정상 작동 확인
- [O] 커밋 메시지 규칙 준수 (ex. `[FEAT]`, `[FIX]`, `[REFACTOR]`)
- [O] 컨벤션 준수 (코드 스타일, 네이밍 등)
- [O] 불필요한 디버깅 코드, 로그 제거
- [X] 주석 및 TODO 정리 : **주석 제거는 배포된 후 프론트가 연결 성공 이후 삭제하려 합니다.**

## 📣 리뷰어에게 전달할 내용
- **이전 카카오 로그아웃 관련 pr은 close하여 병합하지 않고 이번 새로운 pr을 오픈했습니다.**
- 새로운 환경변수가 추가되었습니다. : KAKAO_LOGOUT_REDIRECT_URI