### PR TITLE
feat: subscription + payment user null

### DIFF
--- a/src/main/java/com/deardream/deardream_be/domain/institution/service/AdminInstitutionService.java
+++ b/src/main/java/com/deardream/deardream_be/domain/institution/service/AdminInstitutionService.java
@@ -5,7 +5,7 @@ import com.deardream.deardream_be.domain.institution.Institution;
 import com.deardream.deardream_be.domain.institution.InstitutionRepository;
 import com.deardream.deardream_be.domain.institution.dto.DeleteUsersRequestDto;
 import com.deardream.deardream_be.domain.institution.dto.InstitutionUserResponse;
-import com.deardream.deardream_be.domain.payment.PaymentRepository;
+import com.deardream.deardream_be.domain.payment.repository.PaymentRepository;
 import com.deardream.deardream_be.domain.post.repository.PostRepository;
 import com.deardream.deardream_be.domain.recipient.entity.Recipient;
 import com.deardream.deardream_be.domain.recipient.repository.RecipientRepository;

--- a/src/main/java/com/deardream/deardream_be/domain/payment/controller/SubscriptionScheduler.java
+++ b/src/main/java/com/deardream/deardream_be/domain/payment/controller/SubscriptionScheduler.java
@@ -1,7 +1,7 @@
 package com.deardream.deardream_be.domain.payment.controller;
 
-import com.deardream.deardream_be.domain.payment.Payment;
-import com.deardream.deardream_be.domain.payment.PaymentRepository;
+import com.deardream.deardream_be.domain.payment.entity.Payment;
+import com.deardream.deardream_be.domain.payment.repository.PaymentRepository;
 import com.deardream.deardream_be.domain.payment.dto.KakaoApproveResponse;
 import com.deardream.deardream_be.domain.payment.service.KakaoPayService;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/deardream/deardream_be/domain/payment/entity/Payment.java
+++ b/src/main/java/com/deardream/deardream_be/domain/payment/entity/Payment.java
@@ -1,16 +1,13 @@
-package com.deardream.deardream_be.domain.payment;
+package com.deardream.deardream_be.domain.payment.entity;
 
-import com.deardream.deardream_be.domain.family.entity.Family;
 import com.deardream.deardream_be.domain.institution.DeliveryType;
 import com.deardream.deardream_be.domain.user.entity.User;
 import com.deardream.deardream_be.global.common.BaseEntity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
-import org.springframework.data.annotation.CreatedDate;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.ZoneId;
 
 @Entity
@@ -39,7 +36,7 @@ public class Payment extends BaseEntity {
 
     // 가맹점 회원 ID, 결제 준비 API 응답과 일치
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
+    @JoinColumn(name = "user_id", nullable = true)
     private User user;
 
     @NotNull
@@ -51,6 +48,9 @@ public class Payment extends BaseEntity {
 
     @Setter
     private LocalDate approvedAt;
+
+    // 결제 만료일
+    private LocalDate expiredAt;
 
     // 구독 활성화 여부
     private Boolean isActive;
@@ -64,6 +64,7 @@ public class Payment extends BaseEntity {
     public void updateSuccess(String sid) {
         this.sid = sid;
         this.approvedAt = LocalDate.now(ZoneId.of("Asia/Seoul"));
+        this.expiredAt = this.approvedAt.plusMonths(1);
         this.isActive = true;
         this.isSubscription = true;
     }
@@ -71,5 +72,6 @@ public class Payment extends BaseEntity {
     public void updateCancel() {
         this.isActive = false;
         this.isSubscription = false;
+        this.expiredAt =  null;
     }
 }

--- a/src/main/java/com/deardream/deardream_be/domain/payment/entity/Subscription.java
+++ b/src/main/java/com/deardream/deardream_be/domain/payment/entity/Subscription.java
@@ -1,0 +1,62 @@
+package com.deardream.deardream_be.domain.payment.entity;
+
+import com.deardream.deardream_be.domain.family.entity.Family;
+import com.deardream.deardream_be.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "subscription")
+public class Subscription {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private LocalDateTime startedAt;
+
+    private LocalDateTime expiredAt;
+
+    @Enumerated(EnumType.STRING)
+    private SubscriptionStatus status;
+
+    // 대표자가 결제를 진행합니다.
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    private User user;
+
+    // 대표자(결제한 사용자)의 가족
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "family_id", nullable = false, unique = true)
+    private Family family;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "last_payment_id")
+    private Payment payment;
+
+    public boolean isValid() {
+        return status == SubscriptionStatus.ACTIVE && LocalDateTime.now().isBefore(expiredAt);
+    }
+
+    public void cancel() {
+        this.status = SubscriptionStatus.CANCLE;
+    }
+
+    public void expire() {
+        this.status = SubscriptionStatus.EXPIRED;
+    }
+
+
+
+
+
+}

--- a/src/main/java/com/deardream/deardream_be/domain/payment/entity/SubscriptionStatus.java
+++ b/src/main/java/com/deardream/deardream_be/domain/payment/entity/SubscriptionStatus.java
@@ -1,0 +1,7 @@
+package com.deardream.deardream_be.domain.payment.entity;
+
+public enum SubscriptionStatus {
+    ACTIVE, // 활성화된 구독
+    CANCLE, // 비활성화된 구독
+    EXPIRED // 만료된 구독
+}

--- a/src/main/java/com/deardream/deardream_be/domain/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/deardream/deardream_be/domain/payment/repository/PaymentRepository.java
@@ -1,7 +1,7 @@
-package com.deardream.deardream_be.domain.payment;
+package com.deardream.deardream_be.domain.payment.repository;
 
 
-import com.deardream.deardream_be.domain.family.entity.Family;
+import com.deardream.deardream_be.domain.payment.entity.Payment;
 import com.deardream.deardream_be.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;

--- a/src/main/java/com/deardream/deardream_be/domain/payment/repository/SubscriptionRepository.java
+++ b/src/main/java/com/deardream/deardream_be/domain/payment/repository/SubscriptionRepository.java
@@ -1,0 +1,7 @@
+package com.deardream.deardream_be.domain.payment.repository;
+
+import com.deardream.deardream_be.domain.payment.entity.Subscription;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SubscriptionRepository extends JpaRepository<Subscription, Long> {
+}

--- a/src/main/java/com/deardream/deardream_be/domain/payment/service/KakaoPayService.java
+++ b/src/main/java/com/deardream/deardream_be/domain/payment/service/KakaoPayService.java
@@ -1,11 +1,10 @@
 package com.deardream.deardream_be.domain.payment.service;
 
 
-import com.deardream.deardream_be.domain.family.entity.Family;
 import com.deardream.deardream_be.domain.family.repository.FamilyRepository;
 import com.deardream.deardream_be.domain.institution.DeliveryType;
-import com.deardream.deardream_be.domain.payment.Payment;
-import com.deardream.deardream_be.domain.payment.PaymentRepository;
+import com.deardream.deardream_be.domain.payment.entity.Payment;
+import com.deardream.deardream_be.domain.payment.repository.PaymentRepository;
 import com.deardream.deardream_be.domain.payment.dto.KakaoApproveResponse;
 import com.deardream.deardream_be.domain.payment.dto.KakaoReadyResponse;
 import com.deardream.deardream_be.domain.payment.exception.PaymentErrorCode;
@@ -17,7 +16,6 @@ import com.deardream.deardream_be.global.apiPayload.exception.GeneralException;
 import com.deardream.deardream_be.global.config.KakaoPayConfig;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.catalina.LifecycleState;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
@@ -26,9 +24,7 @@ import org.springframework.web.client.RestTemplate;
 
 import java.time.LocalDate;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/deardream/deardream_be/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/deardream/deardream_be/domain/payment/service/PaymentService.java
@@ -1,9 +1,7 @@
 package com.deardream.deardream_be.domain.payment.service;
 
-import com.deardream.deardream_be.domain.family.entity.Family;
-import com.deardream.deardream_be.domain.family.repository.FamilyRepository;
-import com.deardream.deardream_be.domain.payment.Payment;
-import com.deardream.deardream_be.domain.payment.PaymentRepository;
+import com.deardream.deardream_be.domain.payment.entity.Payment;
+import com.deardream.deardream_be.domain.payment.repository.PaymentRepository;
 import com.deardream.deardream_be.domain.payment.dto.SubscriptionDto;
 import com.deardream.deardream_be.domain.user.entity.User;
 import com.deardream.deardream_be.domain.user.repository.UserRepository;
@@ -18,7 +16,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -61,4 +58,5 @@ public class PaymentService {
                 .build()).collect(Collectors.toList());
 
     }
+
 }

--- a/src/main/java/com/deardream/deardream_be/domain/payment/service/SubscriptionService.java
+++ b/src/main/java/com/deardream/deardream_be/domain/payment/service/SubscriptionService.java
@@ -1,0 +1,23 @@
+package com.deardream.deardream_be.domain.payment.service;
+
+import com.deardream.deardream_be.domain.payment.repository.SubscriptionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SubscriptionService {
+    /*
+    결제 성공 시 Payment 저장
+    해당 유저가 이미 Subscription 을 가지고 있다면 갱신
+    없다면 새로 생성
+    상태는 ACTIVE, 1개월 후 만료
+     */
+    private final SubscriptionRepository subscriptionRepository;
+
+    @Transactional
+    public void createOrUpdateSubscription(){}
+
+}


### PR DESCRIPTION
---
name: PR_TEMPLATE
about: Pull Request 작성을 위한 템플릿
title: '구독 엔티티 생성(초안)'
labels: 'feat'
assignees: 'hyesuhan'
---

## 📌 작업 내용
- 결제와 달리 구독이 필요해서 테이블을 만들었습니다. Erdcloud 수정 예정입니다.

## 🔍 주요 변경 사항
- payment에서 userId 가 nullable = ture로 수정했습니다. (가족 테이블 지울 때 문제 발생)
- 현재 subscription 과 payment 테이블이 수정되었습니다.
- 다만 현재는 초안입니다. 더 수정 예정이나, 프론트 단에서 급하게 userId가 null 이어야 한다고 해서 수정했습니다.

## 🧪 테스트 결과
- [, ] 직접 실행하여 정상 동작 확인함
- [x] 주요 시나리오에 대한 테스트 완료
- [ ] 예외 상황/경계 조건 확인함 (선택)

## 📎 관련 이슈
- #90 

## ✅ 체크리스트
- [ ] 빌드/테스트 정상 작동 확인
- [ ] 커밋 메시지 규칙 준수 (ex. `[FEAT]`, `[FIX]`, `[REFACTOR]`)
- [ ] 컨벤션 준수 (코드 스타일, 네이밍 등)
- [ ] 불필요한 디버깅 코드, 로그 제거
- [ ] 주석 및 TODO 정리

## 📣 리뷰어에게 전달할 내용
- 저랑 구독이랑 결제 관련해서 조금 더 이야기 해봐용!
- 그리고 생각해보니 단방향이어도 nullable= true 처리 (즉, 없애도 fk null 로 채우기 방법) 또는 한번에 cascade로 삭제하는 방식을 생각해봅시다!
