### PR TITLE
[FEAT] redirectUri를 parameter로 받게 추가함

### DIFF
--- a/src/main/java/com/deardream/deardream_be/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/deardream/deardream_be/domain/auth/controller/AuthController.java
@@ -2,10 +2,12 @@ package com.deardream.deardream_be.domain.auth.controller;
 
 import com.deardream.deardream_be.domain.auth.dto.KakaoLoginResponseDto;
 import com.deardream.deardream_be.domain.auth.service.AuthService;
+import com.deardream.deardream_be.domain.auth.util.WhiteRedirectUriList;
 import com.deardream.deardream_be.domain.jwt.JwtUtil;
 import com.deardream.deardream_be.domain.user.entity.User;
 import com.deardream.deardream_be.domain.user.repository.UserRepository;
 import com.deardream.deardream_be.global.apiPayload.ApiResponse;
+import com.deardream.deardream_be.global.apiPayload.code.status.ErrorStatus;
 import com.deardream.deardream_be.global.apiPayload.exception.GeneralException;
 import com.deardream.deardream_be.global.apiPayload.exception.OnKakaoLoginValidation;
 import com.deardream.deardream_be.global.util.RedisUtil;
@@ -28,9 +30,18 @@ public class AuthController {
     private final AuthService authService;
 
     @GetMapping("/login/kakao")         // 여기로 들어오는 code가 카카오가 준 인가코드
-    public ApiResponse<KakaoLoginResponseDto> kakaoLogin(@RequestParam("code") String code, @RequestParam(value = "state", required = false) Long familyId, HttpServletRequest request) {
+    public ApiResponse<KakaoLoginResponseDto> kakaoLogin(@RequestParam("code") String code, @RequestParam(value = "redirectUri") String redirectUri, @RequestParam(value = "state", required = false) Long familyId) {
 
-        KakaoLoginResponseDto loginResponseDto = authService.loginWithKakao(code, familyId, request);
+        log.info("Received redirectUri={}", redirectUri);
+
+        if (!WhiteRedirectUriList.getAllowedRedirectUris().contains(redirectUri)) {
+            boolean allowed = WhiteRedirectUriList.getAllowedRedirectUris().contains(redirectUri);
+            log.info("Is redirectUri allowed? {}", allowed);
+
+            throw new GeneralException(ErrorStatus._INVALID_REDIRECT_URI);
+        }
+
+        KakaoLoginResponseDto loginResponseDto = authService.loginWithKakao(code, redirectUri, familyId);
         return ApiResponse.onSuccess(loginResponseDto);
 
     }

--- a/src/main/java/com/deardream/deardream_be/domain/auth/service/AuthService.java
+++ b/src/main/java/com/deardream/deardream_be/domain/auth/service/AuthService.java
@@ -5,7 +5,7 @@ import com.deardream.deardream_be.domain.user.entity.User;
 import jakarta.servlet.http.HttpServletRequest;
 
 public interface AuthService {
-    KakaoLoginResponseDto loginWithKakao(String code, Long familyId, HttpServletRequest request); // OAuth 로그인 후 사용자 정보 등록 or 조회
+    KakaoLoginResponseDto loginWithKakao(String code, String redirectUri, Long familyId); // OAuth 로그인 후 사용자 정보 등록 or 조회
     void logout(String accessToken);
     String logoutWithKakaoAccount(HttpServletRequest request);
 }

--- a/src/main/java/com/deardream/deardream_be/domain/auth/service/AuthServiceImplementation.java
+++ b/src/main/java/com/deardream/deardream_be/domain/auth/service/AuthServiceImplementation.java
@@ -41,18 +41,7 @@ public class AuthServiceImplementation implements AuthService {
 
     @Override
     @Transactional
-    public KakaoLoginResponseDto loginWithKakao(String code, Long familyId, HttpServletRequest request) {
-
-        // host 정보로 redirectUri 결정
-        String host = request.getHeader("host");
-        log.info("카카오 로그인 요청 host 헤더: {}", host);
-        String redirectUri = switch (host) {
-            case "localhost:3000" -> "http://localhost:3000/profile";
-            case "localhost:8080" -> "http://localhost:8080/profile";
-            case "deardream.site", "www.deardream.site" -> "https://www.deardream.site/profile";
-            case "vote-dream.p-e.kr" -> "https://vote-dream.p-e.kr/profile";
-            default -> "https://www.deardream.site/profile";
-        };
+    public KakaoLoginResponseDto loginWithKakao(String code, String redirectUri, Long familyId) {
 
         // 1. 카카오에서 access token 요청
         KakaoDto.OAuthToken tokenResponse = kakaoUtil.getAccessToken(code, redirectUri);

--- a/src/main/java/com/deardream/deardream_be/domain/auth/util/WhiteRedirectUriList.java
+++ b/src/main/java/com/deardream/deardream_be/domain/auth/util/WhiteRedirectUriList.java
@@ -1,0 +1,16 @@
+package com.deardream.deardream_be.domain.auth.util;
+
+import java.util.Set;
+
+public class WhiteRedirectUriList {
+    private static final Set<String> ALLOWED_REDIRECT_URIS = Set.of(
+            "https://www.deardream.site/profile",
+            "https://www.deardream.site/admin/login",
+            "http://localhost:3000/profile",
+            "http://localhost:3000/admin/login"
+    );
+
+    public static Set<String> getAllowedRedirectUris() {
+        return ALLOWED_REDIRECT_URIS;
+    }
+}

--- a/src/main/java/com/deardream/deardream_be/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/deardream/deardream_be/global/apiPayload/code/status/ErrorStatus.java
@@ -47,6 +47,7 @@ public enum ErrorStatus implements BaseErrorCode {
     _INSTITUTION_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "400", "이미 해당 기관이 존재합니다."),
     _FILE_EXTENSION_ERROR(HttpStatus.BAD_REQUEST, "400", "지원하지 않는 파일 확장자입니다. (pdf, jpg, jpeg, png)"),
     _INSTITUTION_INFO_MISMATCH(HttpStatus.BAD_REQUEST, "400", "해당 기관이 존재하지 않습니다. 기관명과 기관 전화번호를 다시 확인해주세요."),
+    _INVALID_REDIRECT_URI(HttpStatus.BAD_REQUEST, "400", "유효하지 않은 REDIRECT URI입니다."),
 
     // 401 Unauthorized
     _UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "401", "인증이 필요합니다."),


### PR DESCRIPTION
---
name: 오지현
about: redirectUri
title: redirectUri를 parameter로 받게 설정을 추가하였습니다.
labels: closes #95 
assignees: 한혜수
---

## 📌 작업 내용
- 기존 : 카카오 로그인 시 redirectUri의 싱크를 프론트와 맞춰야 해서 host로 redirectUri를 구분하게끔 로직을 뒀었습니다.
- 현재 변경사항 : 기존 로직에 문제가 있어 관련 코드를 삭제하고, 프론트와의 redirectUri 싱크를 쉽게 맞추도록 프론트가 사용한 redirectUri를 params로 받게 로직을 추가하였습니다.

## 🔍 주요 변경 사항
- auth관련 파일, user관련 파일, whiteRedirectUriList 파일 추가 (whiteRedirectUriList : 프론트에서 보내는 redirectUri가 해당 화이트 리스트에 있지 않을 경우 _NOT_VALID_REDIRECT_URI 오류를 반환합니다.)

## 🧪 테스트 결과
- [x] 직접 실행하여 정상 동작 확인함
- [x] 주요 시나리오에 대한 테스트 완료
- [x] 예외 상황/경계 조건 확인함 (선택)

## 📎 관련 이슈
- closes #95 

## ✅ 체크리스트
- [x] 빌드/테스트 정상 작동 확인
- [x] 커밋 메시지 규칙 준수 (ex. `[FEAT]`, `[FIX]`, `[REFACTOR]`)
- [x] 컨벤션 준수 (코드 스타일, 네이밍 등)
- [x] 불필요한 디버깅 코드, 로그 제거
- [x] 주석 및 TODO 정리

## 📣 리뷰어에게 전달할 내용
- 오늘 내에 마감해야 하는 내용이어서 로컬에서 테스트한 후 바로 병합했습니다
