### PR TITLE
[FEAT] 토큰 재발급 로직 추가

### DIFF
--- a/src/main/java/com/deardream/deardream_be/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/deardream/deardream_be/domain/auth/controller/AuthController.java
@@ -3,22 +3,13 @@ package com.deardream.deardream_be.domain.auth.controller;
 import com.deardream.deardream_be.domain.auth.dto.KakaoLoginResponseDto;
 import com.deardream.deardream_be.domain.auth.service.AuthService;
 import com.deardream.deardream_be.domain.auth.util.WhiteRedirectUriList;
-import com.deardream.deardream_be.domain.jwt.JwtUtil;
-import com.deardream.deardream_be.domain.user.entity.User;
-import com.deardream.deardream_be.domain.user.repository.UserRepository;
 import com.deardream.deardream_be.global.apiPayload.ApiResponse;
 import com.deardream.deardream_be.global.apiPayload.code.status.ErrorStatus;
 import com.deardream.deardream_be.global.apiPayload.exception.GeneralException;
-import com.deardream.deardream_be.global.apiPayload.exception.OnKakaoLoginValidation;
-import com.deardream.deardream_be.global.util.RedisUtil;
-import jakarta.servlet.http.HttpServletResponse;
-import lombok.Getter;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.annotation.Lazy;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
-import io.jsonwebtoken.Jwts;
 import jakarta.servlet.http.HttpServletRequest;
 
 @RestController
@@ -29,7 +20,8 @@ public class AuthController {
 
     private final AuthService authService;
 
-    @GetMapping("/login/kakao")         // 여기로 들어오는 code가 카카오가 준 인가코드
+    @Operation(summary = "인가코드와 redirectUri를 통해 카카오 서버로부터 정보를 내려받습니다.")
+    @GetMapping("/login/kakao")
     public ApiResponse<KakaoLoginResponseDto> kakaoLogin(@RequestParam("code") String code, @RequestParam(value = "redirectUri") String redirectUri, @RequestParam(value = "state", required = false) Long familyId) {
 
         log.info("Received redirectUri={}", redirectUri);
@@ -47,55 +39,21 @@ public class AuthController {
     }
 
 
+    @Operation(summary = "토큰을 재발급 받습니다.")
     @PostMapping("/reissue")
-    public void reissueToken(@RequestHeader("Authorization") String refreshTokenHeader) {
-//        String refreshToken = refreshTokenHeader.replace("Bearer ", "");
+    public ApiResponse<KakaoLoginResponseDto> reissueToken(@RequestHeader("Authorization") String token) {
+        try {
+            String refreshToken = token.replace("Bearer ", "").trim();
+            KakaoLoginResponseDto responseDto = authService.reissueToken(refreshToken);
+            return ApiResponse.onSuccess(responseDto);
 
-//        // 1. 토큰에서 kakaoId 추출
-//        Long kakaoId = Long.valueOf(Jwts.parserBuilder()
-//                .setSigningKey(jwtUtil.getSecret().getBytes())
-//                .build()
-//                .parseClaimsJws(refreshToken)
-//                .getBody()
-//                .getSubject());
-//
-//        log.debug("토큰 이메일 추출");
-//
-//        // 2. Redis에서 refresh token 유효성 확인
-//        String storedRefreshToken = redisUtil.getData("refresh:" + kakaoId);
-//        if (storedRefreshToken == null || !storedRefreshToken.equals(refreshToken)) {
-//            throw new IllegalStateException("유효하지 않은 refresh token입니다.");
-//        }
-//
-//        log.debug("리프레쉬 토큰 유효성 확인");
-//
-//        // 3. 사용자 조회 -> 없을 시 에러
-//        User user = userRepository.findByKakaoId(kakaoId)
-//                .orElseThrow(() -> new IllegalStateException("사용자 정보를 찾을 수 없습니다."));
-//
-//        log.debug("사용자 조회");
-//
-//        // 4. 새로운 토큰 발급
-//        String newAccessToken = authService.generateAccessToken(user);
-//        String newRefreshToken = authService.generateRefreshToken(user);
-//
-//        log.debug("새 토큰 발급");
-//
-//        redisUtil.deleteData(refreshToken);
-//        redisUtil.setDataExpire("refresh:" + kakaoId, newRefreshToken, REFRESH_EXP_TIME);
-//
-//        log.debug("데이터 지우고 만료기간 처리");
-//
-//        KakaoLoginResponseDto newRefreshTokenResponse = KakaoLoginResponseDto.builder()
-//                .email(user.getEmail())
-//                .name(user.getName())
-//                .accessToken(newAccessToken)
-//                .refreshToken(newRefreshToken)
-//                .build();
-//
-//        return ApiResponse.onSuccess(newRefreshTokenResponse);
+        } catch (Exception e) {
+            log.error("[Reissue Error] 리프레시 토큰 재발급 실패", e);
+            throw new GeneralException(ErrorStatus._TOKEN_INVALID);
+        }
     }
 
+    @Operation(summary = "일반 로그아웃 : 로그아웃 시 재로그인이 필요하지 않습니다.")
     @PostMapping("/logout")
     public ApiResponse<String> logout(@RequestHeader("Authorization") String token) {
         String accessToken = token.replace("Bearer ", "");
@@ -103,6 +61,7 @@ public class AuthController {
         return ApiResponse.onSuccess("로그아웃에 성공했습니다.");
     }
 
+    @Operation(summary = "카카오 계정과 함께 로그아웃 : 로그아웃 시 재로그인이 필요합니다.")
     @GetMapping("/logout/kakao-account")
     public ApiResponse<String> logoutKakaoAccount(@RequestHeader(value = "Authorization") String token, HttpServletRequest request) {
         if (token != null && !token.isBlank()) {

--- a/src/main/java/com/deardream/deardream_be/domain/auth/service/AuthService.java
+++ b/src/main/java/com/deardream/deardream_be/domain/auth/service/AuthService.java
@@ -8,4 +8,5 @@ public interface AuthService {
     KakaoLoginResponseDto loginWithKakao(String code, String redirectUri, Long familyId); // OAuth 로그인 후 사용자 정보 등록 or 조회
     void logout(String accessToken);
     String logoutWithKakaoAccount(HttpServletRequest request);
+    KakaoLoginResponseDto reissueToken(String refreshToken);
 }

--- a/src/main/java/com/deardream/deardream_be/domain/auth/service/AuthServiceImplementation.java
+++ b/src/main/java/com/deardream/deardream_be/domain/auth/service/AuthServiceImplementation.java
@@ -92,11 +92,70 @@ public class AuthServiceImplementation implements AuthService {
                 .build();
     }
 
+    @Override
+    @Transactional(readOnly = true)
+    public KakaoLoginResponseDto reissueToken(String refreshToken) {
+
+        // Bearer prefix 제거
+        if (refreshToken.startsWith("Bearer ")) {
+            refreshToken = refreshToken.substring(7).trim();
+        } else {
+            refreshToken = refreshToken.trim();
+        }
+
+        // 1. JWT 파싱 (유효성 검사)
+        try {
+            jwtUtil.parseClaims(refreshToken);
+        } catch (Exception e) {
+            log.error("[Reissue] 유효하지 않은 리프레시 토큰: {}", refreshToken, e);
+            throw new GeneralException(ErrorStatus._TOKEN_INVALID);
+        }
+
+        // 2. JWT type 클레임 체크 (access/refresh 구분)
+        String tokenType = jwtUtil.parseClaims(refreshToken).get("type", String.class);
+        if (!"refresh".equals(tokenType)) {
+            log.error("[Reissue] 잘못된 토큰 타입(type): {}", tokenType);
+            throw new GeneralException(ErrorStatus._TOKEN_INVALID);
+        }
+
+        // 3. kakaoId 추출 및 Redis key 설정
+        Long kakaoId = jwtUtil.getKakaoId(refreshToken);
+        String redisKey = "refresh:" + kakaoId;
+
+        // 4. redis에 저장된 리프레시 토큰과 비교
+        String storedRefreshToken = redisUtil.getData(redisKey);
+        if (storedRefreshToken == null || !storedRefreshToken.equals(refreshToken)) {
+            log.error("[Reissue] 저장된 토큰과 불일치 또는 만료 (탈취 위험). kakaoId: {}", kakaoId);
+            throw new GeneralException(ErrorStatus._TOKEN_INVALID);
+        }
+
+        // 5. 사용자 정보 조회
+        User user = userRepository.findByKakaoId(kakaoId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
+
+        // 6. 새 토큰 생성
+        String newAccessToken = jwtUtil.createAccessToken(user.getKakaoId(), user.getRole(), user.getId());
+        String newRefreshToken = jwtUtil.createRefreshToken(user.getKakaoId(), user.getRole(), user.getId());
+
+        // 7. Redis 갱신 (기존 리프레시 토큰 삭제 후 새 토큰 저장)
+        redisUtil.deleteData(redisKey);
+        redisUtil.setDataExpire(redisKey, newRefreshToken, REFRESH_EXP_TIME);
+
+        // 8. DTO 반환
+        log.info("[Reissue] 새 토큰 발급 완료 for kakaoId={}", user.getKakaoId());
+        return KakaoLoginResponseDto.builder()
+                .name(user.getName())
+                .isRegistered(true)
+                .isFamilyRegistered(user.getFamily() != null)
+                .kakaoId(user.getKakaoId())
+                .newAccessToken(newAccessToken)
+                .newRefreshToken(newRefreshToken)
+                .build();
+    }
+
 
     // 기본 로그아웃 - 토큰만 만료
     public void logout(String accessToken) {
-
-        // kakaoUtil.logout(accessToken);
 
         // 1. jwt 유효성 검사 및 파싱
         Long kakaoId = jwtUtil.getKakaoId(accessToken);


### PR DESCRIPTION
---
name: 오지현
about: 토큰 재발급 기능
title: 토큰 재발급 기능을 추가했습니다.
labels: open #18 
assignees: 한혜수
---

## 📌 작업 내용
- 리프레쉬 토큰을 통해 토큰을 재발급 받는 로직을 추가했습니다.

## 🔍 주요 변경 사항
- authController, authServiceImplementation 파일 수정했습니다.
- 리프레쉬 토큰을 통해 액세스 토큰과 리프레쉬 토큰을 재발급 받을 수 있습니다.

## 🧪 테스트 결과
- [O] 직접 실행하여 정상 동작 확인함
- [O] 주요 시나리오에 대한 테스트 완료
- [O] 예외 상황/경계 조건 확인함 (선택)

## 📎 관련 이슈
- open #18 

## ✅ 체크리스트
- [O] 빌드/테스트 정상 작동 확인
- [O] 커밋 메시지 규칙 준수 (ex. `[FEAT]`, `[FIX]`, `[REFACTOR]`)
- [O] 컨벤션 준수 (코드 스타일, 네이밍 등)
- [O] 불필요한 디버깅 코드, 로그 제거
- [O] 주석 및 TODO 정리

## 📣 리뷰어에게 전달할 내용
- 없습니다.