### PR TITLE
fix: Recipient 쿼리문 중 하나만 나오지 않는 문제 발생

### DIFF
--- a/src/main/java/com/deardream/deardream_be/domain/archive/service/PdfRender.java
+++ b/src/main/java/com/deardream/deardream_be/domain/archive/service/PdfRender.java
@@ -79,7 +79,7 @@ public class PdfRender {
         Family family = familyRepository.findById(familyId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._FAMILY_NOT_FOUND));
 
-        Recipient recipient = recipientRepository.findByFamilyId(familyId)
+        Recipient recipient = recipientRepository.findSingleByFamilyId(familyId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._RECIPIENT_NOT_FOUND));
 
         UploadResult result =  postImageService.uploadPDF(s3Config.getPdfFolder(), fileName, baos.toByteArray());

--- a/src/main/java/com/deardream/deardream_be/domain/payment/Payment.java
+++ b/src/main/java/com/deardream/deardream_be/domain/payment/Payment.java
@@ -72,4 +72,10 @@ public class Payment extends BaseEntity {
         this.isActive = false;
         this.isSubscription = false;
     }
+
+    public void cancelHomeDelivery() {
+        this.user = null;
+        this.isSubscription = false;
+        this.isActive = false;
+    }
 }

--- a/src/main/java/com/deardream/deardream_be/domain/recipient/repository/RecipientRepository.java
+++ b/src/main/java/com/deardream/deardream_be/domain/recipient/repository/RecipientRepository.java
@@ -3,7 +3,9 @@ package com.deardream.deardream_be.domain.recipient.repository;
 import com.deardream.deardream_be.domain.family.entity.Family;
 import com.deardream.deardream_be.domain.institution.Institution;
 import com.deardream.deardream_be.domain.recipient.entity.Recipient;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
@@ -15,4 +17,6 @@ public interface RecipientRepository extends JpaRepository<Recipient, Long> {
     boolean existsByLeaderId(Long leaderId);
 
     void deleteAllByFamily(Family family);
+    @Query("SELECT r FROM Recipient r WHERE r.family.id =: familyId")
+    Optional<Recipient> findSingleByFamilyId(@Param("familyId") Long familyId);
 }


### PR DESCRIPTION
---
name: PR_TEMPLATE
about: Pull Request 작성을 위한 템플릿
title: 'Pdf 재생성 로직 오류'
labels: 'FIX'
assignees: '오지현'
---

## 📌 작업 내용
- 현재 Recipient에 Family도 있고 Leader도 존재해서 Join 시 Recipient가 하나만 나오지 않는 문제가 있습니다. 이를 해결하기 위해 쿼리문으로 해결하려 합니다.

## 🔍 주요 변경 사항
- Recipient 에서 findSingleByFamilyId를 추가했습니다.

## 🧪 테스트 결과
- [ ] 직접 실행하여 정상 동작 확인함
- [ ] 주요 시나리오에 대한 테스트 완료
- [ ] 예외 상황/경계 조건 확인함 (선택)

## 📎 관련 이슈
- #127 

## ✅ 체크리스트
- [ ] 빌드/테스트 정상 작동 확인
- [ ] 커밋 메시지 규칙 준수 (ex. `[FEAT]`, `[FIX]`, `[REFACTOR]`)
- [ ] 컨벤션 준수 (코드 스타일, 네이밍 등)
- [ ] 불필요한 디버깅 코드, 로그 제거
- [ ] 주석 및 TODO 정리

## 📣 리뷰어에게 전달할 내용
- 근데 특별한 이유를 전혀 모르겠어요. 로컬에서는 아주 잘되는데 배포에서 안되네요?
