### PR TITLE
[REFACTOR] 가족 생성 시 대표자의 relation/otherRelation 디폴트 값 들어가게 수정

### DIFF
--- a/src/main/java/com/deardream/deardream_be/domain/family/service/FamilyServiceImplementation.java
+++ b/src/main/java/com/deardream/deardream_be/domain/family/service/FamilyServiceImplementation.java
@@ -9,6 +9,7 @@ import com.deardream.deardream_be.domain.post.Post;
 import com.deardream.deardream_be.domain.post.repository.PostRepository;
 import com.deardream.deardream_be.domain.recipient.entity.Recipient;
 import com.deardream.deardream_be.domain.recipient.repository.RecipientRepository;
+import com.deardream.deardream_be.domain.user.Relation;
 import com.deardream.deardream_be.domain.user.entity.User;
 import com.deardream.deardream_be.domain.user.repository.UserRepository;
 import com.deardream.deardream_be.global.apiPayload.code.status.ErrorStatus;
@@ -47,6 +48,9 @@ public class FamilyServiceImplementation implements FamilyService {
         if (user.getFamily() != null) {
             throw new GeneralException(ErrorStatus._FAMILY_ALREADY_REGISTERED);
         }
+
+        // 대표자 relation 기본 설정
+        user.initializeLeaderRelation();
 
         // 3. Family 엔티티 초기화
         Family family = new Family();

--- a/src/main/java/com/deardream/deardream_be/domain/user/entity/User.java
+++ b/src/main/java/com/deardream/deardream_be/domain/user/entity/User.java
@@ -115,4 +115,10 @@ public class User extends BaseEntity {
     public void deleteFamily() {
         this.family = null;
     }
+
+    // 대표자의 기본 relation/otherRelation 설정
+    public void initializeLeaderRelation() {
+        this.relation = Relation.OTHER;
+        this.otherRelation = "대표자";
+    }
 }


### PR DESCRIPTION
---
name: 오지현
about: 디폴트 값 설정
title: 가족 생성 시 대표자 디폴트 값 설정
labels: 없음
assignees: 없음
---

## 📌 작업 내용
- 프론트 측 요청으로 가족 생성 시 대표자의 relation=OTHER, otherRelation="대표자"로 설정되게 수정했습니다.

## 🔍 주요 변경 사항
- user 엔티티, familyService 수정

## 🧪 테스트 결과
- [ ] 직접 실행하여 정상 동작 확인함
- [ ] 주요 시나리오에 대한 테스트 완료
- [ ] 예외 상황/경계 조건 확인함 (선택)

## 📎 관련 이슈
- 없음

## ✅ 체크리스트
- [ ] 빌드/테스트 정상 작동 확인
- [ ] 커밋 메시지 규칙 준수 (ex. `[FEAT]`, `[FIX]`, `[REFACTOR]`)
- [ ] 컨벤션 준수 (코드 스타일, 네이밍 등)
- [ ] 불필요한 디버깅 코드, 로그 제거
- [ ] 주석 및 TODO 정리

## 📣 리뷰어에게 전달할 내용
- 없습니다.
