### PR TITLE
[FIX] 회원 탈퇴 시 payment userId FK에 걸려서 탈퇴 안되면 문제 해결

### DIFF
--- a/src/main/java/com/deardream/deardream_be/domain/user/service/UserServiceWithdrawImplementation.java
+++ b/src/main/java/com/deardream/deardream_be/domain/user/service/UserServiceWithdrawImplementation.java
@@ -3,11 +3,13 @@ package com.deardream.deardream_be.domain.user.service;
 
 import com.deardream.deardream_be.domain.family.entity.Family;
 import com.deardream.deardream_be.domain.family.repository.FamilyRepository;
+import com.deardream.deardream_be.domain.payment.Payment;
 import com.deardream.deardream_be.domain.post.repository.PostRepository;
 import com.deardream.deardream_be.domain.recipient.repository.RecipientRepository;
 import com.deardream.deardream_be.domain.user.Role;
 import com.deardream.deardream_be.domain.user.entity.User;
 import com.deardream.deardream_be.domain.user.repository.UserRepository;
+import com.deardream.deardream_be.domain.payment.PaymentRepository;
 import com.deardream.deardream_be.domain.archive.repository.ArchiveRepository;
 import com.deardream.deardream_be.domain.archive.repository.BookmarkRepository;
 import com.deardream.deardream_be.global.apiPayload.code.status.ErrorStatus;
@@ -27,6 +29,7 @@ public class UserServiceWithdrawImplementation implements UserServiceWithdraw {
     private final UserRepository userRepository;
     private final FamilyRepository familyRepository;
     private final PostRepository postRepository;
+    private final PaymentRepository paymentRepository;
     private final RecipientRepository recipientRepository;
     private final ArchiveRepository archiveRepository;
 
@@ -77,14 +80,21 @@ public class UserServiceWithdrawImplementation implements UserServiceWithdraw {
         }
         userRepository.saveAll(users);
 
-        // 2. leader의 familyId null 처리
+        // 2. leader와 연관된 payment userId null 처리
+        List<Payment> payments = paymentRepository.findAllByUser(leader);
+        for (Payment payment : payments) {
+            payment.cancelHomeDelivery();
+        }
+        paymentRepository.saveAll(payments);
+
+        // 3. leader의 familyId null 처리
         leader.deleteFamily();
         userRepository.save(leader);
 
-        // 3. family 삭제
+        // 4. family 삭제
         familyRepository.delete(family);
 
-        // 4. 본인 LEADER USER 삭제
+        // 5. 본인 LEADER USER 삭제
         userRepository.delete(leader);
 
     }


### PR DESCRIPTION
---
name: 오지현
about: 회원 탈퇴
title: 회원 탈퇴 시 payment userId FK에 걸려서 탈퇴 안되면 문제 해결
labels: closes #107 
assignees: 한혜수
---

## 📌 작업 내용
- 회원 탈퇴 시 payment userId FK에 걸려서 탈퇴 안되면 문제 해결

## 🔍 주요 변경 사항
- UserWithdrawImplementation에 payment관련 로직이 없어서 추가

## 🧪 테스트 결과
- [ ] 직접 실행하여 정상 동작 확인함
- [ ] 주요 시나리오에 대한 테스트 완료
- [ ] 예외 상황/경계 조건 확인함 (선택)

## 📎 관련 이슈
- closes #107 

## ✅ 체크리스트
- [ ] 빌드/테스트 정상 작동 확인
- [ ] 커밋 메시지 규칙 준수 (ex. `[FEAT]`, `[FIX]`, `[REFACTOR]`)
- [ ] 컨벤션 준수 (코드 스타일, 네이밍 등)
- [ ] 불필요한 디버깅 코드, 로그 제거
- [ ] 주석 및 TODO 정리

## 📣 리뷰어에게 전달할 내용
- 없습니다