### PR TITLE
[FEAT] 유저 등록 시 userRequestDto에서 profileImage가 url로 올 경우 기능 추가

### DIFF
--- a/src/main/java/com/deardream/deardream_be/domain/post/service/PostImageService.java
+++ b/src/main/java/com/deardream/deardream_be/domain/post/service/PostImageService.java
@@ -16,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.*;
+import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -116,7 +117,46 @@ public class PostImageService {
 
     }
 
+    public UploadResult uploadImageFromUrl(String folder, String fileName, String imageUrl) {
+        HttpURLConnection connection = null;
+        InputStream inputStream = null;
+        try {
+            URL newUrl = new URL(imageUrl);
+            connection = (HttpURLConnection) newUrl.openConnection();
+            connection.setConnectTimeout(10000);
+            connection.setReadTimeout(10000);
+            int responseCode = connection.getResponseCode();
+            if (responseCode != HttpURLConnection.HTTP_OK) {
+                throw new GeneralException(ErrorStatus._FILE_DOWNLOAD_ERROR_FROM_URL);
+            }
+            inputStream = connection.getInputStream();
 
+            // S3 업로드
+            ObjectMetadata metadata = new ObjectMetadata();
+            metadata.setContentType(connection.getContentType());
 
+            int contentLength = connection.getContentLength();
+            if (contentLength > 0) {
+                metadata.setContentLength(contentLength);
+            }
 
+            String key = folder + "/" + fileName;
+            amazonS3Client.putObject(s3Config.getBucket(), key, inputStream, metadata);
+
+            String url = amazonS3Client.getUrl(s3Config.getBucket(), key).toString();
+            return new UploadResult(key, url);
+
+        } catch (IOException e) {
+            throw new GeneralException(ErrorStatus._FILE_UPLOAD_ERROR);
+        } finally {
+            if (inputStream != null) {
+                try {
+                    inputStream.close();
+                } catch (IOException ignored) {}
+            }
+            if (connection != null) {
+                connection.disconnect();
+            }
+        }
+    }
 }

--- a/src/main/java/com/deardream/deardream_be/domain/user/dto/UserRequestDto.java
+++ b/src/main/java/com/deardream/deardream_be/domain/user/dto/UserRequestDto.java
@@ -21,8 +21,7 @@ public class UserRequestDto {
     @NotNull
     private String name;
 
-//    @NotNull
-//    private String profileImage;
+    private String profileImage;
 
     @NotNull
     private LocalDate birth;

--- a/src/main/java/com/deardream/deardream_be/domain/user/service/UserServiceImplementation.java
+++ b/src/main/java/com/deardream/deardream_be/domain/user/service/UserServiceImplementation.java
@@ -67,11 +67,20 @@ public class UserServiceImplementation implements UserService {
         String profileImageUrl = null;
         String profileImageKey = null;
 
+        // 3-1. file이 존재할 때(파일 업로드 우선)
         if(profileImage != null && !profileImage.isEmpty()) {
             validateProfileImage(profileImage);
 
             String fileName = "profile_" + kakaoId + "_" + System.currentTimeMillis() + "_" + profileImage.getOriginalFilename();
             UploadResult uploadResult = postImageService.uploadFile(s3Config.getProfileFolder(), fileName, profileImage);
+
+            profileImageKey = uploadResult.getKey();
+            profileImageUrl = postImageService.getFilesUrl(profileImageKey);
+        }
+        // 3-2. file이 존재하지 않고, userRequestDto에 카카오프로필 이미지 url이 있을 때
+        else if (userRequestDto.getProfileImage() != null && !userRequestDto.getProfileImage().isEmpty()) {
+            String fileName = "profile_" + kakaoId + "_" + System.currentTimeMillis() + ".jpg";
+            UploadResult uploadResult = postImageService.uploadImageFromUrl(s3Config.getProfileFolder(), fileName, userRequestDto.getProfileImage());
 
             profileImageKey = uploadResult.getKey();
             profileImageUrl = postImageService.getFilesUrl(profileImageKey);

--- a/src/main/java/com/deardream/deardream_be/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/deardream/deardream_be/global/apiPayload/code/status/ErrorStatus.java
@@ -19,6 +19,7 @@ public enum ErrorStatus implements BaseErrorCode {
     _PDF_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "500", "PDF 업로드에 실패하였습니다."),
     _PDF_DOWNLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "500", "PDF 다운로드에 실패하였습니다."),
     _PDF_DELETE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "500", "PDF 삭제에 실패하였습니다."),
+    _FILE_DOWNLOAD_ERROR_FROM_URL(HttpStatus.INTERNAL_SERVER_ERROR, "500", "URL로부터 파일을 다운받는 것에 실패했습니다."),
 
     // 400 Bad Request
     _BAD_REQUEST(HttpStatus.BAD_REQUEST, "400", "잘못된 요청입니다."),


### PR DESCRIPTION
---
name: 오지현
about: profileImage 처리
title: 유저 등록 시 userRequestDto에서 profileImage가 url로 올 경우 기능 추가
labels: open #98 
assignees: 한혜수
---

## 📌 작업 내용
- 유저 등록 시 userRequestDto에서 profileImage가 url로 올 경우 처리 가능하게끔 함

## 🔍 주요 변경 사항
- userController, userRequestDto, userService 수정
- [프론트의 요구사항]
**1. userRequestDto(profileImage : url)랑 file(profileImage : file, 사용자가 넣은 사진) 둘 다 값이 있으면 file 우선 적용**
**2. userRequestDto(profileImage : url)은 값이 있는데 file(profileImage : file, 사용자가 넣은 사진) 없으면 url 우선 적용**
**3. 둘 다 없으면 그냥 null 값**

- 필요한 기능 : 조건 분기문 + 사진 url로부터 사진을 다운로드 받아서 S3에 저장하는 새로운 함수 (file말고 url로도 사진을 받아서 저장할 수 있게 해야함) <- 이렇게 기능 추가함

## 🧪 테스트 결과
- [x] 직접 실행하여 정상 동작 확인함
- [x] 주요 시나리오에 대한 테스트 완료
- [x] 예외 상황/경계 조건 확인함 (선택)

## 📎 관련 이슈
- open #98 

## ✅ 체크리스트
- [x] 빌드/테스트 정상 작동 확인
- [x] 커밋 메시지 규칙 준수 (ex. `[FEAT]`, `[FIX]`, `[REFACTOR]`)
- [x] 컨벤션 준수 (코드 스타일, 네이밍 등)
- [x] 불필요한 디버깅 코드, 로그 제거
- [x] 주석 및 TODO 정리

## 📣 리뷰어에게 전달할 내용
- 위의 프론트 요구사항에 맞는지 확인 한 번 더 부탁드립니다.
