### PR TITLE
fix: 플랜 해지 - 가정/기관

### DIFF
--- a/src/main/java/com/deardream/deardream_be/domain/family/entity/Family.java
+++ b/src/main/java/com/deardream/deardream_be/domain/family/entity/Family.java
@@ -58,4 +58,14 @@ public class Family extends BaseEntity {
     public void updateFamilyInviteLink(String inviteLinkToken) {
         this.familyLink = inviteLinkToken;
     }
+
+    // family 활성화 상태 업데이트
+    public void setFamilyActive() {
+        this.isActive = true;
+        this.hasSubscribed = true;
+    }
+
+    public void setFamilyDeActive() {
+        this.isActive = false;
+    }
 }

--- a/src/main/java/com/deardream/deardream_be/domain/family/service/FamilyServiceImplementation.java
+++ b/src/main/java/com/deardream/deardream_be/domain/family/service/FamilyServiceImplementation.java
@@ -5,6 +5,7 @@ import com.deardream.deardream_be.domain.family.dto.FamilyMembersResponseDto;
 import com.deardream.deardream_be.domain.family.dto.FamilyResponseDto;
 import com.deardream.deardream_be.domain.family.entity.Family;
 import com.deardream.deardream_be.domain.family.repository.FamilyRepository;
+import com.deardream.deardream_be.domain.institution.DeliveryType;
 import com.deardream.deardream_be.domain.post.Post;
 import com.deardream.deardream_be.domain.post.repository.PostRepository;
 import com.deardream.deardream_be.domain.recipient.entity.Recipient;
@@ -68,6 +69,12 @@ public class FamilyServiceImplementation implements FamilyService {
         if (recipient != null) {
             recipient.assignFamily(tempFamilySaved);
             recipientRepository.save(recipient);
+        }
+
+        // 6-1. (한혜수) 받는 분의 플랜이 기관이라면 바로 Active
+        if(recipient.getDeliveryType() == DeliveryType.INSTITUTION) {
+            tempFamilySaved.setFamilyActive();
+            familyRepository.save(tempFamilySaved);
         }
 
         return FamilyResponseDto.of(tempFamilySaved);

--- a/src/main/java/com/deardream/deardream_be/domain/payment/controller/PaymentController.java
+++ b/src/main/java/com/deardream/deardream_be/domain/payment/controller/PaymentController.java
@@ -26,17 +26,21 @@ public class PaymentController {
 
     @Operation(summary = "플랜 서비스를 해제합니다. 결제한 사람의 아이디를 넣어주세요.")
     @PatchMapping("/cancel")
-    public ApiResponse<Void> cancelPlan(
+    public ApiResponse<?> cancelPlan(
             @RequestParam Long userId
     ) {
-        return ApiResponse.onSuccess(paymentService.deActive(userId));
+        paymentService.deActive(userId);
+        return ApiResponse.onSuccess("플랜 서비스가 해제되었습니다.");
     }
 
     @Operation(summary = "현재 플랜 상태를 나타냅니다.")
     @GetMapping("/status/{familyId}")
-    public ApiResponse<?> getPlanStatus(
+    public ApiResponse getPlanStatus(
             @PathVariable Long familyId
     ) {
-        return ApiResponse.onSuccess(paymentService.getPlanStatus(familyId));
+        boolean isActive =  paymentService.getPlanStatus(familyId);
+        return ApiResponse.onSuccess(
+                isActive ? "현재 플랜이 활성화되어 있습니다." : "현재 플랜이 비활성화되어 있습니다."
+        );
     }
 }

--- a/src/main/java/com/deardream/deardream_be/domain/payment/controller/PaymentController.java
+++ b/src/main/java/com/deardream/deardream_be/domain/payment/controller/PaymentController.java
@@ -35,12 +35,21 @@ public class PaymentController {
 
     @Operation(summary = "현재 플랜 상태를 나타냅니다.")
     @GetMapping("/status/{familyId}")
-    public ApiResponse getPlanStatus(
+    public ApiResponse<?> getPlanStatus(
             @PathVariable Long familyId
     ) {
         boolean isActive =  paymentService.getPlanStatus(familyId);
         return ApiResponse.onSuccess(
                 isActive ? "현재 플랜이 활성화되어 있습니다." : "현재 플랜이 비활성화되어 있습니다."
         );
+    }
+
+    @Operation(summary = "기관 플랜 해지 후 재가입")
+    @PostMapping("/rejoin")
+    public ApiResponse<?> rejoinPlan(
+            @RequestParam Long familyId
+    ) {
+        paymentService.rejoinByInstitution(familyId);
+        return ApiResponse.onSuccess("플랜이 재가입되었습니다.");
     }
 }

--- a/src/main/java/com/deardream/deardream_be/domain/payment/service/KakaoPayService.java
+++ b/src/main/java/com/deardream/deardream_be/domain/payment/service/KakaoPayService.java
@@ -145,6 +145,12 @@ public class KakaoPayService {
 
         payment.updateSuccess(response.getSid());
 
+        Family family = familyRepository.findByLeaderId(payment.getUser().getId())
+                .orElseThrow(() -> new GeneralException(ErrorStatus._FAMILY_NOT_FOUND));
+
+        // 가정일 경우 결제 후 Family 활성화
+        family.setFamilyActive();
+
         return response;
     }
 

--- a/src/main/java/com/deardream/deardream_be/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/deardream/deardream_be/domain/payment/service/PaymentService.java
@@ -9,6 +9,7 @@ import com.deardream.deardream_be.domain.payment.exception.PaymentErrorCode;
 import com.deardream.deardream_be.domain.payment.exception.PaymentException;
 import com.deardream.deardream_be.domain.user.entity.User;
 import com.deardream.deardream_be.domain.user.repository.UserRepository;
+import com.deardream.deardream_be.global.apiPayload.code.BaseCode;
 import com.deardream.deardream_be.global.apiPayload.code.status.ErrorStatus;
 import com.deardream.deardream_be.global.apiPayload.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
@@ -66,14 +67,19 @@ public class PaymentService {
 
     // 플랜 해지
     @Transactional
-    public Void deActive(Long userId) {
+    public BaseCode deActive(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
+
+        Family family = familyRepository.findByLeaderId(user.getId())
+                .orElseThrow(() -> new GeneralException(ErrorStatus._FAMILY_NOT_FOUND));
 
         Payment lastPayment = paymentRepository.findLastestByUser(user)
                 .orElseThrow(() -> new PaymentException(PaymentErrorCode._PAYMENT_REQUEST_FAILED));
 
         lastPayment.updateCancel();
+
+        family.setFamilyDeActive();
 
         log.info("구독 해지: {} - {}", user.getId(), lastPayment.getTid());
 
@@ -84,27 +90,23 @@ public class PaymentService {
         Family family = familyRepository.findById(familyId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._FAMILY_NOT_FOUND));
 
+        if(!family.getIsActive()) {
+            throw new GeneralException(ErrorStatus._SUBSCRIPTION_IS_NOT_ACTIVE);
+        }
+
         User Leader = family.getLeader();
 
         if (Leader == null) {
             throw new GeneralException(ErrorStatus._FAMILY_LEADER_NOT_FOUND);
-        }
+        }else {
+            Payment payment = paymentRepository.findLastestByUser(Leader)
+                    .orElseThrow(() -> new PaymentException(PaymentErrorCode._PAYMENT_REQUEST_FAILED));
 
-        Payment lastPayment = paymentRepository.findLastestByUser(Leader)
-                .orElseThrow(() -> new PaymentException(PaymentErrorCode._PAYMENT_REQUEST_FAILED));
-
-        if (lastPayment.getIsActive() && lastPayment.getApprovedAt() != null) {
-            LocalDate expiredDate = lastPayment.getApprovedAt().plusDays(30);
-            if (expiredDate.isAfter(LocalDate.now())) {
-                log.info("✅ 구독 활성 상태 - 만료일: {}", expiredDate);
+            if(payment.getIsActive() || family.getIsActive()) {
                 return true;
             } else {
-                log.info("⚠️ 구독 만료됨 - 만료일: {}", expiredDate);
-                throw new GeneralException(ErrorStatus._SUBSCRIPTION_EXPIRED);
+                throw new GeneralException(ErrorStatus._SUBSCRIPTION_IS_NOT_ACTIVE);
             }
-        } else {
-            log.info("❌ 구독 비활성 상태입니다.");
-            throw new GeneralException(ErrorStatus._SUBSCRIPTION_IS_NOT_ACTIVE);
         }
 
     }

--- a/src/main/java/com/deardream/deardream_be/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/deardream/deardream_be/domain/payment/service/PaymentService.java
@@ -110,4 +110,16 @@ public class PaymentService {
         }
 
     }
+
+    @Transactional
+    public void rejoinByInstitution(Long familyId) {
+        Family family = familyRepository.findById(familyId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._FAMILY_NOT_FOUND));
+
+        if (family.getIsActive()) {
+            throw new GeneralException(ErrorStatus._SUBSCRIPTION_IS_ALREADY_ACTIVE);
+        }
+
+        family.setFamilyActive();
+    }
 }

--- a/src/main/java/com/deardream/deardream_be/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/deardream/deardream_be/global/apiPayload/code/status/ErrorStatus.java
@@ -84,7 +84,8 @@ public enum ErrorStatus implements BaseErrorCode {
     _INVALID_INSTITUTION_CODE(HttpStatus.BAD_REQUEST, "400", "유효하지 않은 기관 코드입니다."),
     _INSTITUTION_CODE_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "400", "이미 존재하는 기관 코드입니다."),
     _SUBSCRIPTION_EXPIRED(HttpStatus.BAD_REQUEST, "400", "구독이 만료되었습니다. 새로운 구독을 시작해주세요."),
-    _SUBSCRIPTION_IS_NOT_ACTIVE(HttpStatus.BAD_REQUEST, "400", "구독이 활성화되지 않았습니다. 구독을 시작해주세요.")
+    _SUBSCRIPTION_IS_NOT_ACTIVE(HttpStatus.BAD_REQUEST, "400", "구독이 활성화되지 않았습니다. 구독을 시작해주세요."),
+    _SUBSCRIPTION_IS_ALREADY_ACTIVE(HttpStatus.BAD_REQUEST, "400", "구독이 이미 활성화되어 있습니다. 구독 상태를 확인해주세요."),
 
     ;
 


### PR DESCRIPTION
---
name: PR_TEMPLATE
about: Pull Request 작성을 위한 템플릿
title: '가정/기관 플랜에 대한 해지'
labels: 'FIX'
assignees: '오지현'
---

## 📌 작업 내용
- 과거 가정 플랜에서 결제 후에만 해지가 가능한 것을 수정하였습니다.
- 재 결제 시 다시 ACtive가 됩니다.
- 기관 플랜의 경우 재 선택시 Active가 됩니다.

## 🔍 주요 변경 사항
- family 생성 service에서 받는 분 배송 타입 == 기관일 경우 isActive가 활성화 되도록 하였습니다.

## 🧪 테스트 결과
- [ ] 직접 실행하여 정상 동작 확인함
- [ ] 주요 시나리오에 대한 테스트 완료
- [ ] 예외 상황/경계 조건 확인함 (선택)

## 📎 관련 이슈
- #111 

## ✅ 체크리스트
- [ ] 빌드/테스트 정상 작동 확인
- [ ] 커밋 메시지 규칙 준수 (ex. `[FEAT]`, `[FIX]`, `[REFACTOR]`)
- [ ] 컨벤션 준수 (코드 스타일, 네이밍 등)
- [ ] 불필요한 디버깅 코드, 로그 제거
- [ ] 주석 및 TODO 정리

## 📣 리뷰어에게 전달할 내용
- family service에서 createFamily 부분을 수정하였습니다.
