### PR TITLE
[FIX] [수신자 -> 가족생성 -> 결제] 로 변경된 플로우에 맞게 코드 수정

### DIFF
--- a/src/main/java/com/deardream/deardream_be/domain/family/entity/Family.java
+++ b/src/main/java/com/deardream/deardream_be/domain/family/entity/Family.java
@@ -33,16 +33,16 @@ public class Family extends BaseEntity {
     private String familyLink;
 
     @Column(name = "is_active")
-    private Boolean isActive;
+    private Boolean isActive = false;
 
     @Column(name = "has_subscribed")
-    private Boolean hasSubscribed;
+    private Boolean hasSubscribed = false;
 
     @OneToMany(mappedBy = "family", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<Post> posts;
 
-    @OneToMany(mappedBy = "family", cascade = CascadeType.REMOVE, orphanRemoval = true)
-    private List<Recipient> recipients;
+    @OneToOne(mappedBy = "family", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private Recipient recipient;
 
     @OneToMany(mappedBy = "family", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<MonthlyArchive> monthlyArchives;

--- a/src/main/java/com/deardream/deardream_be/domain/family/service/FamilyServiceImplementation.java
+++ b/src/main/java/com/deardream/deardream_be/domain/family/service/FamilyServiceImplementation.java
@@ -64,16 +64,25 @@ public class FamilyServiceImplementation implements FamilyService {
         user.joinFamilyAsLeader(tempFamilySaved);
         userRepository.save(user);
 
-        // 6. 대표자의 recipient가 있다면 familyId 연동
+        // 6. family 관련 작업
         Recipient recipient = recipientRepository.findByLeaderId(user.getId()).orElse(null);
         if (recipient != null) {
+            // 6-1. 대표자의 recipient가 있다면 familyId 연동
             recipient.assignFamily(tempFamilySaved);
             recipientRepository.save(recipient);
+
+            // 6-2. 해당 userId를 leaderId로 가진 recipient의 DeliveryType 조회
+            DeliveryType recipientDeliveryType = recipient.getDeliveryType();
+            // 기관 플랜일 시 : isActive, hasSubscribed true 세팅 (기본값은 false)
+            if(recipientDeliveryType == DeliveryType.INSTITUTION) {
+                tempFamilySaved.setFamilyActive();
+            }
+            familyRepository.save(tempFamilySaved);
         }
 
-        // 6-1. (한혜수) 받는 분의 플랜이 기관/가정(가정은 결제가 우선이므로)이라면 바로 Active
-        tempFamilySaved.setFamilyActive();
-        familyRepository.save(tempFamilySaved);
+//        // 6-1. (한혜수) 받는 분의 플랜이 기관/가정(가정은 결제가 우선이므로)이라면 바로 Active
+//        tempFamilySaved.setFamilyActive();
+//        familyRepository.save(tempFamilySaved);
 
         return FamilyResponseDto.of(tempFamilySaved);
     }
@@ -157,9 +166,14 @@ public class FamilyServiceImplementation implements FamilyService {
 
         String inviteLinkToken = family.getFamilyLink();
 
-        // 2. 이미 familyLink가 있다면 예외 발생
+        // 2-1. 예외처리 : 이미 familyLink가 있다면 예외 발생
         if(inviteLinkToken != null) {
             throw new GeneralException(ErrorStatus._INVITE_LINK_ALREADY_EXISTS);
+        }
+
+        // 2-2. 예외처리 : 활성화가 안 된 가족일 시 예외 발생
+        if(family.getIsActive() == false){
+            throw new GeneralException(ErrorStatus._FAMILY_NOT_ACTIVE);
         }
 
         // 3. familyLink가 없을 때만 새로 생성
@@ -181,6 +195,10 @@ public class FamilyServiceImplementation implements FamilyService {
             throw new GeneralException(ErrorStatus._FAMILY_NOT_FOUND);
         }
 
+        if(family.getIsActive() == false){
+            throw new GeneralException(ErrorStatus._FAMILY_NOT_ACTIVE);
+        }
+
         return family.getFamilyLink();
     }
 
@@ -197,16 +215,47 @@ public class FamilyServiceImplementation implements FamilyService {
         User user = userRepository.findByKakaoId(kakaoId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
 
-        // 3. 이미 가족에 속해 있는지 확인
-        if (user.getFamily() != null) {
-            throw new GeneralException(ErrorStatus._ALREADY_IN_FAMILY);
+        // 3. 이미 가족에 속해 있는 경우 케이스 분기
+        Family myFamily = user.getFamily();
+        if(myFamily != null) {
+            if(myFamily.getIsActive() == true && myFamily.getHasSubscribed() == true){
+                throw new GeneralException(ErrorStatus._ALREADY_IN_ACTIVE_FAMILY);
+            }
+            else if(!myFamily.getIsActive() && myFamily.getHasSubscribed() == true){
+                throw new GeneralException(ErrorStatus._FAMILY_NOT_ACTIVE);
+            }
+            else if(!myFamily.getIsActive() && !myFamily.getHasSubscribed()){
+                deleteTemporaryFamily(user);
+            }
         }
+
+//        if (user.getFamily() != null) {
+//            throw new GeneralException(ErrorStatus._ALREADY_IN_FAMILY);
+//        }
 
         // 4. User 쪽에 familyId 설정
         user.joinFamilyAsUser(family);
 
         // 5. 저장하면 user.familyId 칼럼에 자동으로 family.getId 반영
         userRepository.save(user);
+    }
+
+
+    // 결제하지 않은 leader가 생성한 임시 가족을 삭제하는 로직 - 가족에 leader만 들어가 있고 다른 user는 없는 상태
+    // leader만 familyId null처리 하고 family를 삭제하면 됨
+    // 가족과 수신자만 생성되어있음 (결제하지 않았을 시 post 작성 불가여서, 가족에 딸린 정보는 수신자밖에 없음)
+    // 가족과 수신자는 cascade 되어 있음, 가족만 삭제하면 수신자 삭제 됨
+    @Transactional
+    public void deleteTemporaryFamily(User leader) {
+        Family family = leader.getFamily();
+
+        // 1. leader의 familyId null 처리
+        leader.deleteFamily();
+        userRepository.save(leader);
+
+        // 2. family 삭제
+        familyRepository.delete(family);
+
     }
 
     // 테스트용 임시 로직

--- a/src/main/java/com/deardream/deardream_be/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/deardream/deardream_be/domain/payment/service/PaymentService.java
@@ -93,13 +93,13 @@ public class PaymentService {
         Family family = familyRepository.findById(familyId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._FAMILY_NOT_FOUND));
 
-        List<Recipient> recipients = family.getRecipients();
+        Recipient recipient = family.getRecipient();
 
-        if(recipients.isEmpty()) {
+        if(recipient == null) {
            throw new GeneralException(ErrorStatus._RECIPIENT_NOT_FOUND);
         }
 
-        DeliveryType status = recipients.get(0).getDeliveryType();
+        DeliveryType status = recipient.getDeliveryType();
         return PlanResponseDto.builder()
                 .isActive(family.getIsActive())
                 .type(status)

--- a/src/main/java/com/deardream/deardream_be/domain/recipient/entity/Recipient.java
+++ b/src/main/java/com/deardream/deardream_be/domain/recipient/entity/Recipient.java
@@ -27,7 +27,7 @@ public class Recipient extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "family_id")
     private Family family;
 

--- a/src/main/java/com/deardream/deardream_be/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/deardream/deardream_be/global/apiPayload/code/status/ErrorStatus.java
@@ -66,6 +66,9 @@ public enum ErrorStatus implements BaseErrorCode {
     _NOT_FAMILY_MEMBER(HttpStatus.FORBIDDEN, "403", "해당 가족의 구성원이 아닙니다."),
     _RECIPIENT_ALREADY_REGISTERED(HttpStatus.FORBIDDEN, "403", "이미 수신자가 등록되어 있습니다. 수신자 수정을 이용해 주세요."),
     _INVITE_LINK_ALREADY_EXISTS(HttpStatus.FORBIDDEN, "403", "가족 초대 링크가 이미 생성되어 있습니다. 가족 초대 링크 조회를 이용해주세요."),
+    _FAMILY_NOT_ACTIVE(HttpStatus.FORBIDDEN, "403", "해당 가족은 구독이 해지되어 있습니다. 따라서 관련 작업이 불가합니다."),
+    _ALREADY_IN_ACTIVE_FAMILY(HttpStatus.FORBIDDEN, "403", "이미 활성화된 가족에 속해있습니다. 가족을 옮길 수 없습니다."),
+
 
     // 404 Not Found
     _TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "404", "해당 토큰을 찾을 수 없습니다."),


### PR DESCRIPTION
---
name: 오지현
about: 수신자 -> 가족생성 -> 결제 플로우
title: 수신자 -> 가족생성 -> 결제 플로우
labels: open #90 
assignees: 한혜수
---

## 📌 작업 내용
- 수신자 -> 가족생성 -> 결제 플로우로 변경됨에 따라 몇 가지 로직을 수정하였습니다.

## 🔍 주요 변경 사항
- 아래 사진에 나와있습니다 (그래도 아래에 정리하였습니다)
- familyServiceImplementation 파일이 수정되었습니다.
- family 생성 api / joinByInviteLink api / familyLink 생성 및 조회 api가 수정되었습니다.

[변경 사항 정리]
1. 가족생성 api

## 🧪 테스트 결과
- [ ] 직접 실행하여 정상 동작 확인함
- [x] 주요 시나리오에 대한 테스트 완료
- [ ] 예외 상황/경계 조건 확인함 (선택)

## 📎 관련 이슈
- open #90 

## ✅ 체크리스트
- [ ] 빌드/테스트 정상 작동 확인
- [ ] 커밋 메시지 규칙 준수 (ex. `[FEAT]`, `[FIX]`, `[REFACTOR]`)
- [ ] 컨벤션 준수 (코드 스타일, 네이밍 등)
- [ ] 불필요한 디버깅 코드, 로그 제거
- [ ] 주석 및 TODO 정리

## 📣 리뷰어에게 전달할 내용
- 아래 사진을 참고해주세요
<img width="999" height="1440" alt="image" src="https://github.com/user-attachments/assets/4801f7d5-1173-44cc-8570-3b33471c1c1e" />

